### PR TITLE
Test adjustments

### DIFF
--- a/macros/tx_gaps.sql
+++ b/macros/tx_gaps.sql
@@ -23,9 +23,9 @@ model_name AS (
         {{ column_block }}
 )
 SELECT
-    block_base.{{ column_block }},
+    block_base.{{ column_block }} as b_block_id,
     {{ column_tx_count }},
-    model_name.{{ column_block }},
+    model_name.{{ column_block }} as t_block_id,
     model_tx_count
 FROM
     block_base

--- a/models/core/core__fact_prices.yml
+++ b/models/core/core__fact_prices.yml
@@ -20,7 +20,6 @@ models:
       - name: TOKEN
         description: "{{ doc('token')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
@@ -29,7 +28,6 @@ models:
       - name: SYMBOL
         description: "{{ doc('symbol')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING


### PR DESCRIPTION
Adds alias to tx_gaps test that was causing a compilation error.
Silences null error on core fact_prices as the labels are in progress. Still warning on silver.