### PR TITLE
update_tests

### DIFF
--- a/models/core/core__fact_receipts.yml
+++ b/models/core/core__fact_receipts.yml
@@ -8,7 +8,6 @@ models:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ

--- a/models/core/core__fact_transactions.yml
+++ b/models/core/core__fact_transactions.yml
@@ -36,7 +36,6 @@ models:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 1

--- a/models/core/core__fact_transfers.yml
+++ b/models/core/core__fact_transfers.yml
@@ -38,7 +38,6 @@ models:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ

--- a/models/silver/curated/silver__transfers_s3.yml
+++ b/models/silver/curated/silver__transfers_s3.yml
@@ -17,6 +17,9 @@ models:
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null:
+              where: _load_timestamp <= current_timestamp - interval '2 hours'
 
       - name: TX_SIGNER
         description: "{{ doc('tx_signer')}}"

--- a/models/silver/streamline/silver__streamline_receipts_final.yml
+++ b/models/silver/streamline/silver__streamline_receipts_final.yml
@@ -15,6 +15,12 @@ models:
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
 
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null:
+              where: _load_timestamp <= current_timestamp - interval '2 hours'
+
       - name: RECEIPT_INDEX
         description: "{{ doc('receipt_index')}}"
 


### PR DESCRIPTION
Alters tests
 - block_timestamp not null test moved from core receipt to silver receipt for the load timestamp buffer
 - block_timestamp on core removed, already on silver
 - block_timestamp not null moved from core transfers to silver for load timestamp buffer