### PR TITLE
add error message cols

### DIFF
--- a/models/descriptions/error_message.md
+++ b/models/descriptions/error_message.md
@@ -1,0 +1,5 @@
+{% docs error_message %}
+
+The error message, if any, associated with the failure.
+
+{% enddocs %}

--- a/models/descriptions/error_type_0.md
+++ b/models/descriptions/error_type_0.md
@@ -1,0 +1,5 @@
+{% docs error_type_0 %}
+
+The top-level error type, which likely pertains to the type of object that failed. For example `ActionError` when a action failed to execute for some reason.
+
+{% enddocs %}

--- a/models/descriptions/error_type_1.md
+++ b/models/descriptions/error_type_1.md
@@ -1,0 +1,5 @@
+{% docs error_type_1 %}
+
+The second level of error type when a receipt has failed. This pertains to the scope in which the error occurred, such as `FunctionCallError`.
+
+{% enddocs %}

--- a/models/descriptions/error_type_2.md
+++ b/models/descriptions/error_type_2.md
@@ -1,0 +1,5 @@
+{% docs error_type_2 %}
+
+The third level of error type which actually pertains to the type of failure. This is commonly `ExecutionError`.
+
+{% enddocs %}

--- a/models/descriptions/receipt_succeeded.md
+++ b/models/descriptions/receipt_succeeded.md
@@ -1,0 +1,5 @@
+{% docs receipt_succeeded %}
+
+A boolean indicating whether the receipt was successfully processed, based on the presence of a Failure message.
+
+{% enddocs %}

--- a/models/silver/streamline/silver__streamline_receipts.sql
+++ b/models/silver/streamline/silver__streamline_receipts.sql
@@ -24,6 +24,17 @@ FINAL AS (
         chunk_hash,
         receipt,
         execution_outcome,
+        execution_outcome :outcome :status :Failure IS NULL AS receipt_succeeded,
+        object_keys(
+            execution_outcome :outcome :status :Failure
+        ) [0] :: STRING AS error_type_0,
+        object_keys(
+            execution_outcome :outcome :status :Failure [error_type_0] :kind
+        ) [0] :: STRING AS error_type_1,
+        object_keys(
+            execution_outcome :outcome :status :Failure [error_type_0] :kind [error_type_1]
+        ) [0] :: STRING AS error_type_2,
+        execution_outcome :outcome :status :Failure [error_type_0] :kind [error_type_1] [error_type_2] :: STRING AS error_message,
         execution_outcome :outcome :receipt_ids :: ARRAY AS outcome_receipts,
         receipt :receiver_id :: STRING AS receiver_id,
         receipt :receipt :Action :signer_id :: STRING AS signer_id,

--- a/models/silver/streamline/silver__streamline_receipts.yml
+++ b/models/silver/streamline/silver__streamline_receipts.yml
@@ -25,6 +25,21 @@ models:
       - name: EXECUTION_OUTCOME
         description: "{{ doc('execution_outcome')}}"
 
+      - name: RECEIPT_SUCCEEDED
+        description: "{{ doc('receipt_succeeded')}}"
+
+      - name: ERROR_TYPE_0
+        description: "{{ doc('error_type_0')}}"
+    
+      - name: ERROR_TYPE_1
+        description: "{{ doc('error_type_1')}}"
+
+      - name: ERROR_TYPE_2
+        description: "{{ doc('error_type_2')}}"
+      
+      - name: ERROR_MESSAGE
+        description: "{{ doc('error_message')}}"
+
       - name: OUTCOME_RECEIPTS
         description: "{{ doc('receipt_outcome_id')}}"
         tests:

--- a/models/silver/streamline/silver__streamline_receipts_final.sql
+++ b/models/silver/streamline/silver__streamline_receipts_final.sql
@@ -43,6 +43,11 @@ append_tx_hash AS (
         r.receiver_id,
         r.signer_id,
         r.receipt_type,
+        r.receipt_succeeded,
+        r.error_type_0,
+        r.error_type_1,
+        r.error_type_2,
+        r.error_message,
         r._load_timestamp,
         r._partition_by_block_number
     FROM
@@ -69,6 +74,11 @@ FINAL AS (
         execution_outcome :outcome :logs :: ARRAY AS logs,
         execution_outcome :proof :: ARRAY AS proof,
         execution_outcome :outcome :metadata :: variant AS metadata,
+        receipt_succeeded,
+        error_type_0,
+        error_type_1,
+        error_type_2,
+        error_message,
         _load_timestamp,
         _partition_by_block_number
     FROM

--- a/models/silver/streamline/silver__streamline_receipts_final.yml
+++ b/models/silver/streamline/silver__streamline_receipts_final.yml
@@ -69,6 +69,21 @@ models:
       - name: METADATA
         description: "{{ doc('metadata')}}"
 
+      - name: RECEIPT_SUCCEEDED
+        description: "{{ doc('receipt_succeeded')}}"
+
+      - name: ERROR_TYPE_0
+        description: "{{ doc('error_type_0')}}"
+    
+      - name: ERROR_TYPE_1
+        description: "{{ doc('error_type_1')}}"
+
+      - name: ERROR_TYPE_2
+        description: "{{ doc('error_type_2')}}"
+      
+      - name: ERROR_MESSAGE
+        description: "{{ doc('error_message')}}"
+
       - name: _LOAD_TIMESTAMP
         description: "{{ doc('_load_timestamp')}}"
         tests:


### PR DESCRIPTION
PR adds 4 columns to `silver__streamline_receipts` and `silver__streamline_receipts_final`.  

Transaction status on NEAR is not dependent on all receipts processing. Some may fail, and the transaction may succeed. The point of this PR is to map out receipt status for broad investigation of exactly what causes a transaction to fail. For example, `ExecutionError` commonly leads to a transaction failure, but not always.

The project is configured to append new columns, so this should not break existing workflow in the 2 receipts models. A FR is not possible on `...receipts_final`, so an ALTER TABLE will be required when time for a backfill.

Adding this now will allow for go-forward receipts to be mapped out over the week, and for segmented backfills on dev, as needed, to get a robust sample.

Example of these new columns:

```sql
with failed_txs as (
select
    *
from near.silver.streamline_transactions_final
where block_timestamp::date >= '2023-04-01'
    and tx_status = 'Fail'
limit 1000
),
int_receipts as (
    select * from near.silver.streamline_receipts_final
    where tx_hash in (select distinct tx_hash from failed_txs)
),
receipts AS (
  SELECT
    tx_hash,
    receipt_object_id,
    block_id,
    execution_outcome,
    execution_outcome :outcome :status as execution_status,
    execution_outcome :outcome :status :Failure IS NULL AS receipt_succeeded,
    object_keys(execution_outcome :outcome :status :Failure)[0]::string as error_type_0,
    object_keys(execution_outcome :outcome :status :Failure[error_type_0]:kind)[0]::string as error_type_1,
    object_keys(execution_outcome :outcome :status :Failure[error_type_0]:kind[error_type_1])[0]::string as error_type_2,
    execution_outcome :outcome :status :Failure[error_type_0]:kind[error_type_1][error_type_2]::string as error_message,
    SUM(
      gas_burnt
    ) over (
      PARTITION BY tx_hash
      ORDER BY
        tx_hash DESC
    ) AS receipt_gas_burnt,
    SUM(
      execution_outcome :outcome :tokens_burnt :: NUMBER
    ) over (
      PARTITION BY tx_hash
      ORDER BY
        tx_hash DESC
    ) AS receipt_tokens_burnt
  FROM
    int_receipts
)
select * from receipts
where not receipt_succeeded
order by block_id;
```