### PR TITLE
views on new metadata

### DIFF
--- a/models/descriptions/series_title.md
+++ b/models/descriptions/series_title.md
@@ -1,0 +1,5 @@
+{% docs series_title %}
+
+Title of the NFT series.
+
+{% enddocs %}

--- a/models/gold/core/core__dim_ft_contract_metadata.sql
+++ b/models/gold/core/core__dim_ft_contract_metadata.sql
@@ -1,0 +1,20 @@
+{{ config(
+    materialized = 'view',
+    tags = ['core', 'livequery', 'nearblocks']
+) }}
+
+WITH ft_contract_metadata AS (
+
+    SELECT
+        *
+    FROM
+        {{ ref('silver__ft_contract_metadata') }}
+)
+SELECT
+    contract_address,
+    NAME,
+    symbol,
+    decimals,
+    icon
+FROM
+    ft_contract_metadata

--- a/models/gold/core/core__dim_ft_contract_metadata.yml
+++ b/models/gold/core/core__dim_ft_contract_metadata.yml
@@ -1,0 +1,26 @@
+version: 2
+
+models:
+  - name: core__dim_ft_contract_metadata
+    description: |-
+      Fungible Token contract metadata provided by the Nearblocks NFT endpoint.
+
+    columns:
+      - name: CONTRACT_ADDRESS
+        description: "{{ doc('contract_address')}}"
+
+      - name: NAME
+        description: "{{ doc('name')}}"
+
+      - name: SYMBOL
+        description: "{{ doc('symbol')}}"
+
+      - name: DECIMALS
+        description: "{{ doc('decimals')}}"
+
+      - name: ICON
+        description: "{{ doc('icon')}}"
+
+
+      - name: DATA
+        description: "{{ doc('data')}}"

--- a/models/gold/nft/nft__dim_nft_contract_metadata.sql
+++ b/models/gold/nft/nft__dim_nft_contract_metadata.sql
@@ -1,0 +1,21 @@
+{{ config(
+    materialized = 'view',
+    tags = ['core', 'nft', 'livequery', 'nearblocks']
+) }}
+
+WITH nft_contract_metadata AS (
+
+    SELECT
+        *
+    FROM
+        {{ ref('silver__nft_contract_metadata') }}
+)
+SELECT
+    contract_address,
+    NAME,
+    symbol,
+    base_uri,
+    icon,
+    tokens
+FROM
+    nft_contract_metadata

--- a/models/gold/nft/nft__dim_nft_contract_metadata.yml
+++ b/models/gold/nft/nft__dim_nft_contract_metadata.yml
@@ -1,0 +1,25 @@
+version: 2
+
+models:
+  - name: nft__dim_nft_contract_metadata
+    description: |-
+      NFT Contract-level metadata provided by the Nearblocks NFT endpoint.
+
+    columns:
+      - name: CONTRACT_ADDRESS
+        description: "{{ doc('contract_address')}}"
+      
+      - name: NAME
+        description: "{{ doc('name')}}"
+
+      - name: SYMBOL
+        description: "{{ doc('symbol')}}"
+
+      - name: BASE_URI
+        description: "{{ doc('base_uri')}}"
+
+      - name: ICON
+        description: "{{ doc('icon')}}"
+
+      - name: TOKENS
+        description: "{{ doc('tokens')}}"

--- a/models/gold/nft/nft__dim_nft_series_metadata.sql
+++ b/models/gold/nft/nft__dim_nft_series_metadata.sql
@@ -1,0 +1,21 @@
+{{ config(
+    materialized = 'view',
+    tags = ['core', 'nft', 'pagoda']
+) }}
+
+WITH series_metadata AS (
+
+    SELECT
+        *
+    FROM
+        {{ ref('silver__nft_series_metadata') }}
+)
+SELECT
+    contract_address,
+    series_id,
+    token_metadata :title :: STRING AS series_title,
+    metadata_id,
+    contract_metadata,
+    token_metadata
+FROM
+    series_metadata

--- a/models/gold/nft/nft__dim_nft_series_metadata.yml
+++ b/models/gold/nft/nft__dim_nft_series_metadata.yml
@@ -1,0 +1,24 @@
+version: 2
+
+models:
+  - name: nft__dim_nft_series_metadata
+    description: |-
+      NFT Series-level metadata provided by the Pagoda NFT endpoint.
+
+    columns:
+      - name: CONTRACT_ADDRESS
+        description: "{{ doc('contract_address')}}"
+
+      - name: SERIES_ID
+        description: "{{ doc('series_id')}}"
+      - name: SERIES_TITLE
+        description: "{{ doc('series_title')}}"
+
+      - name: METADATA_ID
+        description: "{{ doc('metadata_id')}}"
+
+      - name: CONTRACT_METADATA
+        description: "{{ doc('contract_metadata')}}"
+
+      - name: TOKEN_METADATA
+        description: "{{ doc('token_metadata')}}"


### PR DESCRIPTION
Adds 3 new views on metadata ingestion

Nearblocks
 - NFT Contract Metadata [docs](https://api.nearblocks.io/api-docs/#/NFTs/get_v1_nfts)
 - FT Contract Metadata [docs](https://api.nearblocks.io/api-docs/#/FTs/get_v1_fts)

Pagoda
- Series-level metadata (via token info) `https://near-mainnet.api.pagoda.co/eapi/v1
/NFT/{contract_account_id}/{token_id}`