### PR TITLE
updating version and switching to use livequery

### DIFF
--- a/models/silver/livequery/livequery__request_pagoda_nft_metadata.sql
+++ b/models/silver/livequery/livequery__request_pagoda_nft_metadata.sql
@@ -75,7 +75,7 @@ lq_request AS (
         series_id,
         metadata_id,
         'https://near-mainnet.api.pagoda.co/eapi/v1/NFT/' || contract_account_id || '/' || token_id AS res_url,
-        ethereum.streamline.udf_api(
+        live.udf_api(
             'GET',
             res_url,
             { 

--- a/packages.yml
+++ b/packages.yml
@@ -4,6 +4,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: "v1.3.0"
+    revision: "v1.9.3"
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]


### PR DESCRIPTION
Updating version to deploy udf

And updating pipeline to use livequery instead of ethereum udf_api

```
Require to run:
- dbt deps
- `dbt run -s livequery_models.deploy.core --vars "{UPDATE_UDFS_AND_SPS: true}" -t dev `
- `dbt run -s livequery_models.deploy.core --vars "{UPDATE_UDFS_AND_SPS: true}" -t  prod`
```