### PR TITLE
rename gold Atlas MAA view before release

### DIFF
--- a/models/gold/atlas/atlas__fact_maas.sql
+++ b/models/gold/atlas/atlas__fact_maas.sql
@@ -4,7 +4,7 @@
 ) }}
 
 SELECT
-    atlas_near_maa_id AS fact_near_maas_id,
+    atlas_maa_id AS fact_maas_id,
     day,
     maa,
     new_maas,
@@ -12,4 +12,4 @@ SELECT
     inserted_timestamp,
     modified_timestamp
 FROM
-    {{ ref('silver__atlas_near_maa') }}
+    {{ ref('silver__atlas_maa') }}

--- a/models/gold/atlas/atlas__fact_maas.yml
+++ b/models/gold/atlas/atlas__fact_maas.yml
@@ -1,12 +1,12 @@
 version: 2
 
 models:
-  - name: atlas__fact_near_maas
+  - name: atlas__fact_maas
     description: |-
       Monthly Active Accounts (wallets) on NEAR, including new and returning wallets, calculated over a rolling 30 day window. An active account, here, is defined as the signing of at least one transaction.
 
     columns:
-      - name: fact_near_maas_id
+      - name: fact_maas_id
         description: "{{ doc('id') }}"
         tests:
           - not_null

--- a/models/silver/atlas/silver__atlas_maa.sql
+++ b/models/silver/atlas/silver__atlas_maa.sql
@@ -97,7 +97,7 @@ FINAL AS (
 SELECT
     {{ dbt_utils.generate_surrogate_key(
         ['day']
-    ) }} AS atlas_near_maa_id,
+    ) }} AS atlas_maa_id,
     day,
     maa,
     new_maas,

--- a/models/silver/atlas/silver__atlas_maa.yml
+++ b/models/silver/atlas/silver__atlas_maa.yml
@@ -1,12 +1,12 @@
 version: 2
 
 models:
-  - name: silver__atlas_near_maa
+  - name: silver__atlas_maa
     description: |-
       Monthly Active Accounts (wallets) on NEAR, including new and returning wallets, calculated over a rolling 30 day window. An active account, here, is defined as the signing of at least one transaction.
 
     columns:
-      - name: atlas_near_maa_id
+      - name: atlas_maa_id
         description: "{{ doc('id') }}"
         tests:
           - not_null


### PR DESCRIPTION
Updates the name of the MAA model(s) to a better convention, dropping `near` from the table name