### PR TITLE
Update daily tests

### DIFF
--- a/.github/workflows/dbt_test.yml
+++ b/.github/workflows/dbt_test.yml
@@ -42,7 +42,7 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt test -s tag:load+
+          dbt test -s models/gold
         continue-on-error: true
 
       - name: Log test results

--- a/models/gold/atlas/atlas__ez_nft_contract_metrics.yml
+++ b/models/gold/atlas/atlas__ez_nft_contract_metrics.yml
@@ -15,9 +15,9 @@ models:
         description: "{ { doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: RECEIVER_ID
         description: "{ { doc('receiver_id')}}"

--- a/models/gold/atlas/atlas__ez_nft_contract_metrics.yml
+++ b/models/gold/atlas/atlas__ez_nft_contract_metrics.yml
@@ -4,34 +4,92 @@ models:
   - name: atlas__ez_nft_contract_metrics
     description: |-
       NFT transaction activities by receiver_id. It includes counts of unique tokens, transfers within the last 24 hours and 3 days, all transfers, unique owners, total transactions, and minting events.
+    tests:
+      - dbt_utils.recency:
+          datepart: days
+          field: inserted_timestamp
+          interval: 1
 
     columns:
       - name: EZ_NFT_CONTRACT_METRICS_ID
         description: "{ { doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: RECEIVER_ID
         description: "{ { doc('receiver_id')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
 
       - name: TOKENS
         description: "{{ doc('tokens_count')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - INTEGER
 
       - name: TRANSFERS_24H
         description: "The count of 'nft_transfer' transactions that occurred in the last 24 hours."
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - INTEGER
 
       - name: TRANSFERS_3D
         description: "The count of 'nft_transfer' transactions that occurred in the last 3 days."
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - INTEGER
 
       - name: ALL_TRANSFERS
         description: "{{ doc('all_transfers')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - INTEGER
 
       - name: OWNERS
         description: "{{ doc('owner_count')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - INTEGER
 
       - name: TRANSACTIONS
         description: "{{ doc('tx_count')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - INTEGER
 
       - name: MINTS
         description: "{{ doc('mint_count')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - INTEGER
 
       - name: INSERTED_TIMESTAMP
         description: "{{ doc('inserted_timestamp')}}"

--- a/models/gold/atlas/atlas__ez_nft_contract_metrics_daily.yml
+++ b/models/gold/atlas/atlas__ez_nft_contract_metrics_daily.yml
@@ -15,9 +15,9 @@ columns:
     description: "{{ doc('id')}}"
     tests:
       - unique:
-          where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
       - not_null:
-          where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
   - name: DAY
     description: "{{ doc('date')}}"

--- a/models/gold/atlas/atlas__ez_nft_contract_metrics_daily.yml
+++ b/models/gold/atlas/atlas__ez_nft_contract_metrics_daily.yml
@@ -4,31 +4,79 @@ models:
   - name: atlas__ez_nft_contract_metrics_daily
     description: |-
       Overview of NFT transactions in NEAR.
+    tests:
+      - dbt_utils.recency:
+          datepart: days
+          field: inserted_timestamp
+          interval: 1
 
 columns:
   - name: EZ_NFT_CONTRACT_METRICS_DAILY_ID
     description: "{{ doc('id')}}"
+    tests:
+      - unique:
+          where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+      - not_null:
+          where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
   - name: DAY
     description: "{{ doc('date')}}"
+    tests:
+      - not_null
 
   - name: RECEIVER_ID
     description: "{{ doc('tx_receiver')}}"
+    tests:
+      - not_null
+      - dbt_expectations.expect_column_values_to_be_in_type_list:
+          column_type_list:
+            - STRING
+            - VARCHAR
 
   - name: TOKENS
     description: "{{ doc('tokens_count')}}"
+    tests:
+      - not_null
+      - dbt_expectations.expect_column_values_to_be_in_type_list:
+          column_type_list:
+            - NUMBER
+            - INTEGER
 
   - name: ALL_TRANSFERS
     description: "{{ doc('all_transfers')}}"
+    tests:
+      - not_null
+      - dbt_expectations.expect_column_values_to_be_in_type_list:
+          column_type_list:
+            - NUMBER
+            - INTEGER
 
   - name: OWNERS
     description: "{{ doc('owner_count')}}"
+    tests:
+      - not_null
+      - dbt_expectations.expect_column_values_to_be_in_type_list:
+          column_type_list:
+            - NUMBER
+            - INTEGER
 
   - name: TRANSACTIONS
     description: "{{ doc('tx_count')}}"
+    tests:
+      - not_null
+      - dbt_expectations.expect_column_values_to_be_in_type_list:
+          column_type_list:
+            - NUMBER
+            - INTEGER
 
   - name: MINTS
     description: "{{ doc('mint_count')}}"
+    tests:
+      - not_null
+      - dbt_expectations.expect_column_values_to_be_in_type_list:
+          column_type_list:
+            - NUMBER
+            - INTEGER
 
   - name: INSERTED_TIMESTAMP
     description: "{{ doc('inserted_timestamp')}}"

--- a/models/gold/atlas/atlas__ez_supply.yml
+++ b/models/gold/atlas/atlas__ez_supply.yml
@@ -4,78 +4,84 @@ models:
   - name: atlas__ez_supply
     description: |-
       A table represeting calculations for the supply of NEAR across various categories, such as staked and locked.
+    tests:
+      - dbt_utils.recency:
+          datepart: days
+          field: inserted_timestamp
+          interval: 1
+    
     columns:
-      - name: utc_date
+      - name: UTC_DATE
         description: "{{ doc('utc_date') }}"
         tests:
           - not_null
-      - name: total_supply
+      - name: TOTAL_SUPPLY
         description: "{{ doc('total_supply') }}"
         tests:
           - not_null
-      - name: total_staked_supply
+      - name: TOTAL_STAKED_SUPPLY
         description: "{{ doc('total_staked_supply') }}"
         tests:
           - not_null
-      - name: total_nonstaked_supply
+      - name: TOTAL_NONSTAKED_SUPPLY
         description: "{{ doc('total_nonstaked_supply') }}"
         tests:
           - not_null
-      - name: circulating_supply
+      - name: CIRCULATING_SUPPLY
         description: "{{ doc('circulating_supply') }}"
         tests:
           - not_null
-      - name: total_locked_supply
+      - name: TOTAL_LOCKED_SUPPLY
         description: "{{ doc('total_locked_supply') }}"
         tests:
           - not_null
-      - name: liquid_supply
+      - name: LIQUID_SUPPLY
         description: "{{ doc('liquid_supply') }}"
         tests:
           - not_null
-      - name: nonliquid_supply
+      - name: NONLIQUID_SUPPLY
         description: "{{ doc('nonliquid_supply') }}"
         tests:
           - not_null
-      - name: staked_locked_supply
+      - name: STAKED_LOCKED_SUPPLY
         description: "{{ doc('staked_locked_supply') }}"
         tests:
           - not_null
-      - name: non_staked_locked_supply
+      - name: NON_STAKED_LOCKED_SUPPLY
         description: "{{ doc('non_staked_locked_supply') }}"
         tests:
           - not_null
-      - name: staked_circulating_supply
+      - name: STAKED_CIRCULATING_SUPPLY
         description: "{{ doc('staked_circulating_supply') }}"
         tests:
           - not_null
-      - name: nonstaked_circulating_supply
+      - name: NONSTAKED_CIRCULATING_SUPPLY
         description: "{{ doc('nonstaked_circulating_supply') }}"
         tests:
           - not_null
-      - name: perc_locked_supply
+      - name: PERC_LOCKED_SUPPLY
         description: "{{ doc('perc_locked_supply') }}"
         tests:
           - not_null
-      - name: perc_circulating_supply
+      - name: PERC_CIRCULATING_SUPPLY
         description: "{{ doc('perc_circulating_supply') }}"
         tests:
           - not_null
-      - name: perc_staked_locked
+      - name: PERC_STAKED_LOCKED
         description: "{{ doc('perc_staked_locked') }}"
         tests:
           - not_null
-      - name: perc_staked_circulating
+      - name: PERC_STAKED_CIRCULATING
         description: "{{ doc('perc_staked_circulating') }}"
         tests:
           - not_null
-      - name: ez_supply_id
+      - name: EZ_SUPPLY_ID
         description: "{{ doc('id') }}"
         tests:
           - not_null
           - unique
-      - name: inserted_timestamp
+      - name: INSERTED_TIMESTAMP
         description: "{{ doc('inserted_timestamp') }}"
 
-      - name: modified_timestamp
+      - name: MODIFIED_TIMESTAMP
         description: "{{ doc('modified_timestamp') }}"

--- a/models/gold/atlas/atlas__fact_accounts_created.sql
+++ b/models/gold/atlas/atlas__fact_accounts_created.sql
@@ -15,13 +15,7 @@ SELECT
     atlas_account_created_id AS fact_accounts_created_id,
     DAY,
     wallets_created,
-    COALESCE(
-        inserted_timestamp,
-        '2000-01-01' :: timestamp_ntz
-    ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
-        '2000-01-01' :: timestamp_ntz
-    ) AS modified_timestamp
+    inserted_timestamp,
+    modified_timestamp
 FROM
     {{ ref('silver__atlas_accounts_created') }}

--- a/models/gold/atlas/atlas__fact_accounts_created.sql
+++ b/models/gold/atlas/atlas__fact_accounts_created.sql
@@ -11,18 +11,17 @@
     tags = ['atlas']
 ) }}
 
-WITH nft_data AS (
-
-    SELECT
-        atlas_account_created_id AS fact_accounts_created_id,
-        DAY,
-        wallets_created,
-        COALESCE(inserted_timestamp, '2000-01-01' :: TIMESTAMP_NTZ) AS inserted_timestamp,
-        COALESCE(modified_timestamp, '2000-01-01' :: TIMESTAMP_NTZ) AS modified_timestamp
-    FROM
-        {{ ref('silver__atlas_accounts_created') }}
-)
 SELECT
-    *
+    atlas_account_created_id AS fact_accounts_created_id,
+    DAY,
+    wallets_created,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01' :: timestamp_ntz
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01' :: timestamp_ntz
+    ) AS modified_timestamp
 FROM
-    nft_data
+    {{ ref('silver__atlas_accounts_created') }}

--- a/models/gold/atlas/atlas__fact_accounts_created.yml
+++ b/models/gold/atlas/atlas__fact_accounts_created.yml
@@ -4,15 +4,34 @@ models:
   - name: atlas__fact_accounts_created
     description: |-
       Daily count of accounts created on NEAR.
+    tests:
+      - dbt_utils.recency:
+          datepart: days
+          field: inserted_timestamp
+          interval: 1
+
     columns:
       - name: FACT_ACCOUNTS_CREATED_ID
         description: "{ { doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: DAY
         description: "{{ doc('date')}}"
+        tests:
+          - not_null
 
       - name: WALLETS_CREATED
         description: "{{ doc('wallets_created')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - INTEGER
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/atlas/atlas__fact_accounts_created.yml
+++ b/models/gold/atlas/atlas__fact_accounts_created.yml
@@ -15,9 +15,9 @@ models:
         description: "{ { doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: DAY
         description: "{{ doc('date')}}"

--- a/models/gold/atlas/atlas__fact_maas.yml
+++ b/models/gold/atlas/atlas__fact_maas.yml
@@ -4,13 +4,20 @@ models:
   - name: atlas__fact_maas
     description: |-
       Monthly Active Accounts (wallets) on NEAR, including new and returning wallets, calculated over a rolling 30 day window. An active account, here, is defined as the signing of at least one transaction.
+    tests:
+      - dbt_utils.recency:
+          datepart: days
+          field: inserted_timestamp
+          interval: 1
 
     columns:
       - name: fact_maas_id
         description: "{{ doc('id') }}"
         tests:
-          - not_null
-          - unique
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: day
         description: "{{ doc('active_day') }}"
@@ -35,10 +42,6 @@ models:
 
       - name: inserted_timestamp
         description: "{{ doc('inserted_timestamp') }}"
-        tests:
-          - not_null
 
       - name: modified_timestamp
         description: "{{ doc('modified_timestamp') }}"
-        tests:
-          - not_null

--- a/models/gold/atlas/atlas__fact_maas.yml
+++ b/models/gold/atlas/atlas__fact_maas.yml
@@ -15,9 +15,9 @@ models:
         description: "{{ doc('id') }}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: day
         description: "{{ doc('active_day') }}"

--- a/models/gold/atlas/atlas__fact_nft_monthly_txs.yml
+++ b/models/gold/atlas/atlas__fact_nft_monthly_txs.yml
@@ -4,17 +4,35 @@ models:
   - name: atlas__fact_nft_monthly_txs
     description: |-
       Summary of NFT transactions from the 'silver__atlas_nft_transactions' table. It provides a daily count of transactions, accounting for a 29-day lookback period for each day within the specified date range.
+    tests:
+      - dbt_utils.recency:
+          datepart: days
+          field: inserted_timestamp
+          interval: 1
 
     columns:
       - name: FACT_NFT_MONTHLY_TXS_ID
         description: "{{ doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: DAY
         description: "{{ doc('date')}}"
+        tests:
+          - not_null
 
       - name: TXNS
         description: "{{ doc('tx_count')}}"
-
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - INTEGER
+                
       - name: INSERTED_TIMESTAMP
         description: "{{ doc('inserted_timestamp')}}"
 

--- a/models/gold/atlas/atlas__fact_nft_monthly_txs.yml
+++ b/models/gold/atlas/atlas__fact_nft_monthly_txs.yml
@@ -15,9 +15,9 @@ models:
         description: "{{ doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: DAY
         description: "{{ doc('date')}}"

--- a/models/gold/core/core__dim_address_labels.yml
+++ b/models/gold/core/core__dim_address_labels.yml
@@ -38,7 +38,7 @@ models:
         tests:
           - not_null
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__dim_address_labels.yml
+++ b/models/gold/core/core__dim_address_labels.yml
@@ -35,6 +35,10 @@ models:
 
       - name: DIM_ADDRESS_LABELS_ID
         description: "{{doc('id')}}"
+        tests:
+          - not_null
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__dim_ft_contract_metadata.yml
+++ b/models/gold/core/core__dim_ft_contract_metadata.yml
@@ -8,25 +8,40 @@ models:
     columns:
       - name: CONTRACT_ADDRESS
         description: "{{ doc('contract_address')}}"
+        tests:
+          - not_null
 
       - name: NAME
         description: "{{ doc('name')}}"
+        tests: 
+          - not_null
 
       - name: SYMBOL
         description: "{{ doc('symbol')}}"
+        tests: 
+          - not_null
 
       - name: DECIMALS
         description: "{{ doc('decimals')}}"
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
 
       - name: ICON
         description: "{{ doc('icon')}}"
-
 
       - name: DATA
         description: "{{ doc('data')}}"
 
       - name: DIM_FT_CONTRACT_METADATA_ID
         description: "{{doc('id')}}"
+        tests:
+          - not_null
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__dim_ft_contract_metadata.yml
+++ b/models/gold/core/core__dim_ft_contract_metadata.yml
@@ -41,7 +41,7 @@ models:
         tests:
           - not_null
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__dim_token_labels.yml
+++ b/models/gold/core/core__dim_token_labels.yml
@@ -4,48 +4,19 @@ models:
   - name: core__dim_token_labels
     description: |-
       Deprecating Soon! The data in this table is now available, and kept up to date in, the view dim_ft_contract_metadata. Please migrate work to use that view by the end of February 2024.
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - token_contract
-            - token
-            - symbol
 
     columns:
       - name: TOKEN
         description: "{{ doc('token')}}"
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
 
       - name: SYMBOL
         description: "{{ doc('symbol')}}"
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
 
       - name: TOKEN_CONTRACT
         description: "{{ doc('token_contract')}}"
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
 
       - name: DECIMALS
         description: "{{ doc('decimals')}}"
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
 
       - name: DIM_TOKEN_LABELS_ID
         description: "{{doc('id')}}"

--- a/models/gold/core/core__fact_actions_events.yml
+++ b/models/gold/core/core__fact_actions_events.yml
@@ -104,7 +104,8 @@ models:
         tests:
           - unique:
               where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
-          - not_null
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{ doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_actions_events.yml
+++ b/models/gold/core/core__fact_actions_events.yml
@@ -4,14 +4,16 @@ models:
   - name: core__fact_actions_events
     description: |-
       This table extracts all action events from a transaction and stores the argument data under action_data.
+    tests:
+      - dbt_utils.recency:
+          datepart: hours
+          field: block_timestamp
+          interval: 3
 
     columns:
       - name: ACTION_ID
         description: "{{ doc('action_id')}}"
         tests:
-          - unique:
-              where: tx_hash != 'J4CZZQrZK6kYPVLkrdbTEpcqhUNZiRxktbMzHviqeGgf'
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
@@ -24,6 +26,8 @@ models:
               column_type_list:
                 - STRING
                 - VARCHAR
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id')}}"
@@ -67,9 +71,8 @@ models:
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: ACTION_INDEX
         description: "{{ doc('action_index')}}"
@@ -91,8 +94,20 @@ models:
       - name: ACTION_DATA
         description: "{{ doc('action_data')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - OBJECT
                 - VARIANT
+
+      - name: FACT_ACTIONS_EVENTS_ID
+        description: "{{ doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null
+
+      - name: INSERTED_TIMESTAMP
+        description: "{{ doc('inserted_timestamp')}}"
+        
+      - name: MODIFIED_TIMESTAMP
+        description: "{{ doc('modified_timestamp')}}"

--- a/models/gold/core/core__fact_actions_events.yml
+++ b/models/gold/core/core__fact_actions_events.yml
@@ -27,7 +27,7 @@ models:
                 - STRING
                 - VARCHAR
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id')}}"
@@ -72,7 +72,7 @@ models:
               column_type_list:
                 - TIMESTAMP_NTZ
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: ACTION_INDEX
         description: "{{ doc('action_index')}}"
@@ -103,9 +103,9 @@ models:
         description: "{{ doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{ doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_actions_events_function_call.yml
+++ b/models/gold/core/core__fact_actions_events_function_call.yml
@@ -4,13 +4,16 @@ models:
   - name: core__fact_actions_events_function_call
     description: |-
       This table extracts all FunctionCall events from actions and decodes the arguments for easy use. If further nested arguments are encoded, the snowflake function `try_base64_decode_string()` will likely work.
+    tests:
+      - dbt_utils.recency:
+          datepart: hours
+          field: block_timestamp
+          interval: 3
 
     columns:
       - name: ACTION_ID
         description: "{{ doc('action_id')}}"
         tests:
-          - unique
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
@@ -23,6 +26,8 @@ models:
               column_type_list:
                 - STRING
                 - VARCHAR
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: RECEIVER_ID
         description: "{{ doc('receiver_id')}}"
@@ -57,9 +62,8 @@ models:
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: ACTION_NAME
         description: "{{ doc('action_name')}}"
@@ -82,7 +86,6 @@ models:
       - name: ARGS
         description: "{{ doc('args')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - VARIANT
@@ -106,6 +109,10 @@ models:
 
       - name: FACT_ACTIONS_EVENTS_FUNCTION_CALL_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_actions_events_function_call.yml
+++ b/models/gold/core/core__fact_actions_events_function_call.yml
@@ -112,7 +112,8 @@ models:
         tests:
           - unique:
               where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
-          - not_null
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_actions_events_function_call.yml
+++ b/models/gold/core/core__fact_actions_events_function_call.yml
@@ -27,7 +27,7 @@ models:
                 - STRING
                 - VARCHAR
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: RECEIVER_ID
         description: "{{ doc('receiver_id')}}"
@@ -63,7 +63,7 @@ models:
               column_type_list:
                 - TIMESTAMP_NTZ
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: ACTION_NAME
         description: "{{ doc('action_name')}}"
@@ -111,9 +111,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_blocks.yml
+++ b/models/gold/core/core__fact_blocks.yml
@@ -4,6 +4,11 @@ models:
   - name: core__fact_blocks
     description: |-
       This table records all the blocks of Near blockchain.
+    tests:
+      - dbt_utils.recency:
+          datepart: hours
+          field: block_timestamp
+          interval: 3
 
     columns:
       - name: BLOCK_ID
@@ -20,9 +25,6 @@ models:
         description: "{{ doc('block_timestamp')}}"
         tests:
           - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ
@@ -52,7 +54,6 @@ models:
       - name: HEADER
         description: "{{ doc('header')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - VARIANT
@@ -61,7 +62,6 @@ models:
       - name: BLOCK_CHALLENGES_RESULT
         description: "{{ doc('block_challenges_result')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - ARRAY
@@ -98,7 +98,6 @@ models:
       - name: CHUNK_MASK
         description: "{{ doc('chunk_mask')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - ARRAY
@@ -117,7 +116,6 @@ models:
       - name: CHUNKS
         description: "{{ doc('chunks')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - ARRAY
@@ -152,7 +150,6 @@ models:
 
       - name: EVENTS
         description: "{{ doc('events')}}"
-
 
       - name: GAS_PRICE
         description: "{{ doc('gas_price')}}"
@@ -299,6 +296,9 @@ models:
 
       - name: FACT_BLOCKS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique
+          - not_null
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_blocks.yml
+++ b/models/gold/core/core__fact_blocks.yml
@@ -33,7 +33,7 @@ models:
         tests:
           - not_null
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
@@ -297,9 +297,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_blocks.yml
+++ b/models/gold/core/core__fact_blocks.yml
@@ -15,7 +15,6 @@ models:
         description: "{{ doc('block_id')}}"
         tests:
           - not_null
-          - unique
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER
@@ -33,7 +32,8 @@ models:
         description: "{{ doc('block_hash')}}"
         tests:
           - not_null
-          - unique
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
@@ -278,7 +278,6 @@ models:
       - name: VALIDATOR_PROPOSALS
         description: "{{ doc('validator_proposals')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - ARRAY
@@ -297,8 +296,10 @@ models:
       - name: FACT_BLOCKS_ID
         description: "{{doc('id')}}"
         tests:
-          - unique
-          - not_null
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_developer_activity.yml
+++ b/models/gold/core/core__fact_developer_activity.yml
@@ -33,7 +33,7 @@ models:
         tests:
           - not_null
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_developer_activity.yml
+++ b/models/gold/core/core__fact_developer_activity.yml
@@ -10,6 +10,8 @@ models:
 
       - name: REPO_NAME
         description: "Repo name"
+        tests:
+          - not_null
 
       - name: ENDPOINT_NAME
         description: "Endpoint name for the data"
@@ -28,6 +30,10 @@ models:
 
       - name: FACT_DEVELOPER_ACTIVITY_ID
         description: "{{doc('id')}}"
+        tests:
+          - not_null
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_logs.sql
+++ b/models/gold/core/core__fact_logs.sql
@@ -12,13 +12,13 @@ WITH logs AS (
         {{ ref('silver__logs_s3') }}
 )
 SELECT
-    tx_hash,
-    block_timestamp,
     block_id,
+    block_timestamp,
+    tx_hash,
+    receipt_object_id,
     receiver_id,
     signer_id,
     clean_log,
-    receipt_object_id,
     gas_burnt,
     COALESCE(
         logs_id,

--- a/models/gold/core/core__fact_logs.yml
+++ b/models/gold/core/core__fact_logs.yml
@@ -15,7 +15,7 @@ models:
         description: "{{ doc('tx_hash')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id')}}"
@@ -81,9 +81,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_logs.yml
+++ b/models/gold/core/core__fact_logs.yml
@@ -4,10 +4,18 @@ models:
   - name: core__fact_logs
     description: |-
       This table extracts all logs from receipts and decodes the arguments for easy use.
+    tests:
+      - dbt_utils.recency:
+          datepart: hours
+          field: block_timestamp
+          interval: 3
 
     columns:
       - name: TX_HASH
         description: "{{ doc('tx_hash')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id')}}"
@@ -20,18 +28,44 @@ models:
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null
 
       - name: RECEIVER_ID
         description: "{{ doc('receiver_id')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
 
       - name: GAS_BURNT
         description: "{{ doc('gas_burnt')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
 
       - name: SIGNER_ID
         description: "{{ doc('signer_id')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
 
       - name: CLEAN_LOG
         description: "{{ doc('clean_log')}}"
@@ -45,6 +79,11 @@ models:
 
       - name: FACT_LOGS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_receipts.yml
+++ b/models/gold/core/core__fact_receipts.yml
@@ -17,7 +17,7 @@ models:
               column_type_list:
                 - TIMESTAMP_NTZ
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
@@ -35,7 +35,7 @@ models:
                 - STRING
                 - VARCHAR
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id')}}"
@@ -126,9 +126,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_receipts.yml
+++ b/models/gold/core/core__fact_receipts.yml
@@ -127,7 +127,8 @@ models:
         tests:
           - unique:
               where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
-          - not_null
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_receipts.yml
+++ b/models/gold/core/core__fact_receipts.yml
@@ -3,6 +3,11 @@ version: 2
 models:
   - name: core__fact_receipts
     description: Decoded and flattened transaction receipts from the block shards.
+    tests:
+      - dbt_utils.recency:
+          datepart: hours
+          field: block_timestamp
+          interval: 3
 
     columns:
       - name: BLOCK_TIMESTAMP
@@ -11,6 +16,8 @@ models:
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
@@ -27,13 +34,12 @@ models:
               column_type_list:
                 - STRING
                 - VARCHAR
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id')}}"
         tests:
-          - not_null
-          - unique:
-              where: tx_hash != 'J4CZZQrZK6kYPVLkrdbTEpcqhUNZiRxktbMzHviqeGgf'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
@@ -42,7 +48,6 @@ models:
       - name: RECEIPT_OUTCOME_ID
         description: "{{ doc('receipt_outcome_id')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - ARRAY
@@ -60,7 +65,6 @@ models:
       - name: ACTIONS
         description: "{{ doc('actions')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - OBJECT
@@ -87,7 +91,6 @@ models:
       - name: STATUS_VALUE
         description: "{{ doc('status_value')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - VARIANT
@@ -96,7 +99,6 @@ models:
       - name: LOGS
         description: "{{ doc('logs')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - ARRAY
@@ -106,7 +108,6 @@ models:
       - name: PROOF
         description: "{{ doc('proof')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - ARRAY
@@ -116,7 +117,6 @@ models:
       - name: METADATA
         description: "{{ doc('metadata')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - VARIANT
@@ -124,6 +124,10 @@ models:
 
       - name: FACT_RECEIPTS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -3,6 +3,11 @@ version: 2
 models:
   - name: core__fact_transactions
     description: Deprecation notice. The column `tx_status` (string, success or fail) is being replaced with `tx_succeeded` (bool). Please migrate work by 2/1/2024! Transactions on the NEAR blockchain.
+    tests:
+      - dbt_utils.recency:
+          datepart: hours
+          field: block_timestamp
+          interval: 3
 
     columns:
       - name: BLOCK_ID
@@ -25,7 +30,6 @@ models:
         description: "{{ doc('tx_hash')}}"
         tests:
           - not_null
-          - unique
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
@@ -34,12 +38,11 @@ models:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
         tests:
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: NONCE
         description: "{{ doc('nonce')}}"
@@ -79,7 +82,6 @@ models:
       - name: TX
         description: "{{ doc('tx')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - OBJECT
@@ -124,11 +126,15 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: fact_transactions_id
+      - name: FACT_TRANSACTIONS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"
-
+        
       - name: MODIFIED_TIMESTAMP
         description: "{{doc('modified_timestamp')}}"

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -7,7 +7,7 @@ models:
       - dbt_utils.recency:
           datepart: hours
           field: block_timestamp
-          interval: 3
+          interval: 6 # TODO - decrease when root cause found
 
     columns:
       - name: BLOCK_ID
@@ -90,6 +90,8 @@ models:
       - name: GAS_USED
         description: "{{ doc('gas_used')}}"
         tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER
@@ -98,6 +100,8 @@ models:
       - name: ATTACHED_GAS
         description: "{{ doc('attached_gas')}}"
         tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER
@@ -106,6 +110,8 @@ models:
       - name: TRANSACTION_FEE
         description: "{{ doc('transaction_fee')}}"
         tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER
@@ -114,6 +120,8 @@ models:
       - name: TX_SUCCEEDED
         description: "{{ doc('tx_succeeded')}}"
         tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - BOOLEAN
@@ -131,7 +139,8 @@ models:
         tests:
           - unique:
               where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
-          - not_null
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -42,7 +42,7 @@ models:
               column_type_list:
                 - TIMESTAMP_NTZ
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: NONCE
         description: "{{ doc('nonce')}}"
@@ -91,7 +91,7 @@ models:
         description: "{{ doc('gas_used')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER
@@ -101,7 +101,7 @@ models:
         description: "{{ doc('attached_gas')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER
@@ -111,7 +111,7 @@ models:
         description: "{{ doc('transaction_fee')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER
@@ -121,7 +121,7 @@ models:
         description: "{{ doc('tx_succeeded')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - BOOLEAN
@@ -138,9 +138,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_transfers.yml
+++ b/models/gold/core/core__fact_transfers.yml
@@ -4,12 +4,18 @@ models:
   - name: core__fact_transfers
     description: |-
       This table records all the Transfer actions of the Near blockchain.
+    tests:
+      - dbt_utils.recency:
+          datepart: hours
+          field: block_timestamp
+          interval: 6 # TODO - decrease when txs final fixed
 
     columns:
       - name: TX_HASH
         description: "{{ doc('tx_hash')}}"
         tests:
-          - not_null
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
@@ -19,8 +25,6 @@ models:
         description: "{{ doc('action_id')}}"
         tests:
           - not_null
-          - unique:
-              where: tx_hash != 'J4CZZQrZK6kYPVLkrdbTEpcqhUNZiRxktbMzHviqeGgf'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
@@ -71,7 +75,8 @@ models:
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id')}}"
         tests:
-          - not_null
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - ARRAY
@@ -102,6 +107,11 @@ models:
 
       - name: FACT_TRANSFERS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/core/core__fact_transfers.yml
+++ b/models/gold/core/core__fact_transfers.yml
@@ -15,7 +15,7 @@ models:
         description: "{{ doc('tx_hash')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
@@ -76,7 +76,7 @@ models:
         description: "{{ doc('receipt_object_id')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - ARRAY
@@ -109,9 +109,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/defi/defi__ez_dex_swaps.yml
+++ b/models/gold/defi/defi__ez_dex_swaps.yml
@@ -9,12 +9,6 @@ models:
     columns:
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
@@ -24,109 +18,39 @@ models:
 
       - name: SWAP_ID
         description: "{{ doc('swap_id')}}"
-        tests:
-          - not_null
-          - unique
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
 
       - name: PLATFORM
         description: "{{ doc('platform')}}"
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
 
       - name: TRADER
         description: "{{ doc('trader')}}"
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
 
       - name: POOL_ID
         description: "{{ doc('pool_id')}}"
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
 
       - name: TOKEN_IN_SYMBOL
         description: "{{ doc('symbol')}}"
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
 
       - name: TOKEN_IN
         description: "{{ doc('token_in')}}"
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
 
       - name: AMOUNT_IN_RAW
         description: "{{ doc('amount_raw')}}"
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-                - DOUBLE
 
       - name: AMOUNT_IN
         description: "{{ doc('amount_in')}}"
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-                - DOUBLE
 
       - name: TOKEN_OUT
         description: "{{ doc('token_out')}}"
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
 
       - name: TOKEN_OUT_SYMBOL
         description: "{{ doc('symbol')}}"
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
 
       - name: AMOUNT_OUT_RAW
         description: "{{ doc('amount_raw')}}"
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-                - DOUBLE
           
       - name: AMOUNT_OUT
         description: "{{ doc('amount_out')}}"
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-                - DOUBLE
 
       - name: EZ_DEX_SWAPS_ID
         description: "{{doc('id')}}"

--- a/models/gold/defi/defi__fact_bridge_activity.yml
+++ b/models/gold/defi/defi__fact_bridge_activity.yml
@@ -4,22 +4,41 @@ models:
   - name: defi__fact_bridge_activity
     description: |-
       Modeled bridge activity, tracking tokens through the NEAR Ecosystem.
+    tests:
+      - dbt_utils.recency:
+          datepart: day
+          field: block_timestamp
+          interval: 1
 
     columns:
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
+        tests:
+          - not_null
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: TX_HASH
         description: "{{ doc('tx_hash')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: TOKEN_ADDRESS
         description: "{{ doc('token_contract')}}"
+        tests:
+          - not_null:
+              where: receipt_succeeded
 
       - name: AMOUNT_UNADJ
         description: "{{ doc('amount_raw')}}"
+        tests:
+          - not_null:
+              where: receipt_succeeded
 
       - name: DESTINATION_ADDRESS
         description: "{{ doc('destination_address')}}"
@@ -29,27 +48,48 @@ models:
 
       - name: PLATFORM
         description: "{{ doc('platform')}}"
+        tests:
+          - not_null
 
       - name: BRIDGE_ADDRESS
         description: "{{ doc('contract_address')}}"
+        tests:
+          - not_null
 
       - name: DESTINATION_CHAIN
         description: "{{ doc('destination_chain')}}"
+        tests:
+          - not_null:
+              where: receipt_succeeded or platform != 'multichain'
 
       - name: SOURCE_CHAIN
         description: "{{ doc('source_chain')}}"
+        tests:
+          - not_null:
+              where: receipt_succeeded or platform != 'multichain'
 
       - name: METHOD_NAME
         description: "{{ doc('method_name')}}"
+        tests:
+          - not_null
 
       - name: DIRECTION
         description: "{{ doc('direction')}}"
+        tests:
+          - not_null
 
       - name: RECEIPT_SUCCEEDED
         description: "{{ doc('receipt_succeeded')}}"
+        tests:
+          - not_null
 
       - name: FACT_BRIDGE_ACTIVITY_ID
         description: "{{ doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{ doc('inserted_timestamp')}}"

--- a/models/gold/defi/defi__fact_bridge_activity.yml
+++ b/models/gold/defi/defi__fact_bridge_activity.yml
@@ -20,13 +20,13 @@ models:
         description: "{{ doc('block_timestamp')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: TX_HASH
         description: "{{ doc('tx_hash')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: TOKEN_ADDRESS
         description: "{{ doc('token_contract')}}"
@@ -87,9 +87,9 @@ models:
         description: "{{ doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{ doc('inserted_timestamp')}}"

--- a/models/gold/defi/defi__fact_dex_swaps.yml
+++ b/models/gold/defi/defi__fact_dex_swaps.yml
@@ -15,7 +15,7 @@ models:
         description: "{{ doc('tx_hash')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id')}}"
@@ -31,7 +31,7 @@ models:
         description: "{{ doc('block_timestamp')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: RECEIVER_ID
         description: "{{ doc('receiver_id')}}"
@@ -78,9 +78,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/defi/defi__fact_dex_swaps.yml
+++ b/models/gold/defi/defi__fact_dex_swaps.yml
@@ -4,41 +4,70 @@ models:
   - name: defi__fact_dex_swaps
     description: |-
       Parses log output data for swap information. It was determined logs must be used over inputs in a FunctionCall as only the output contains actual swap information. See tx AfvgkUxP8taJNBLaZYvFumFrrePpJujb2gjQJz7YbRiM as an example.
+    tests:
+      - dbt_utils.recency:
+          datepart: hours
+          field: block_timestamp
+          interval: 12
 
     columns:
       - name: TX_HASH
         description: "{{ doc('tx_hash')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id')}}"
+        tests:
+          - not_null
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
+        tests:
+          - not_null
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: RECEIVER_ID
         description: "{{ doc('receiver_id')}}"
+        tests:
+          - not_null
 
       - name: SIGNER_ID
         description: "{{ doc('signer_id')}}"
-      
+        tests:
+          - not_null
+
       - name: SWAP_INDEX
         description: "{{ doc('index')}}"
+        tests:
+          - not_null
 
       - name: AMOUNT_OUT_RAW
         description: "{{ doc('amount_out_raw')}}"
+        tests:
+          - not_null
 
       - name: TOKEN_OUT
         description: "{{ doc('token_out')}}"
+        tests:
+          - not_null
 
       - name: AMOUNT_IN_RAW
         description: "{{ doc('amount_in_raw')}}"
+        tests:
+          - not_null
 
       - name: TOKEN_IN
         description: "{{ doc('token_in')}}"
-
+        tests:
+          - not_null
+          
       - name: SWAP_INPUT_DATA
         description: "{{ doc('swap_input_data')}}"
 
@@ -47,6 +76,11 @@ models:
 
       - name: FACT_DEX_SWAPS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/governance/gov__dim_staking_pools.yml
+++ b/models/gold/governance/gov__dim_staking_pools.yml
@@ -15,7 +15,7 @@ models:
         description: "{{ doc('tx_hash') }}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
@@ -25,7 +25,7 @@ models:
         description: "{{ doc('block_timestamp')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ
@@ -71,9 +71,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/governance/gov__dim_staking_pools.yml
+++ b/models/gold/governance/gov__dim_staking_pools.yml
@@ -4,13 +4,18 @@ models:
   - name: gov__dim_staking_pools
     description: |-
       This table contains registered staking pools with NEAR.
+    tests:
+      - dbt_utils.recency:
+          datepart: day
+          field: block_timestamp
+          interval: 30
 
     columns:
       - name: TX_HASH
         description: "{{ doc('tx_hash') }}"
         tests:
-          - not_null
-          - unique
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
@@ -19,7 +24,8 @@ models:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
         tests:
-          - not_null
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ
@@ -45,7 +51,6 @@ models:
       - name: REWARD_FEE_FRACTION
         description: "{{ doc('staking_pool_reward_fee_fraction')}}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - VARIANT
@@ -64,6 +69,11 @@ models:
 
       - name: DIM_STAKING_POOLS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/governance/gov__fact_lockup_actions.yml
+++ b/models/gold/governance/gov__fact_lockup_actions.yml
@@ -8,12 +8,20 @@ models:
     columns:
       - name: TX_HASH
         description: "{{ doc('tx_hash')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
+        tests:
+          - not_null
 
       - name: DEPOSIT
         description: "{{ doc('deposit')}}"
@@ -72,6 +80,11 @@ models:
 
       - name: FACT_LOCKUP_ACTIONS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/governance/gov__fact_lockup_actions.yml
+++ b/models/gold/governance/gov__fact_lockup_actions.yml
@@ -10,13 +10,13 @@ models:
         description: "{{ doc('tx_hash')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
@@ -82,9 +82,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/governance/gov__fact_staking_actions.yml
+++ b/models/gold/governance/gov__fact_staking_actions.yml
@@ -6,34 +6,62 @@ models:
       An updated version of the staking actions table which looks at all logs, instead of just the first receipt.
       There are four actions taken when staking: staking->deposit->unstaking->withdraw.
       Note - in this core view the amount is decimal adjusted by 10^24.
+    tests:
+      - dbt_utils.recency:
+          datepart: day
+          field: block_timestamp
+          interval: 1
 
     columns:
       - name: TX_HASH
         description: "{{ doc('tx_hash') }}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id') }}"
+        tests:
+          - not_null
 
       - name: ADDRESS
         description: "{{ doc('pool_address') }}"
+        tests:
+          - not_null
 
       - name: SIGNER_ID
         description: "{{ doc('signer_id') }}"
+        tests:
+          - not_null
 
       - name: ACTION
         description: "{{ doc('staking_action') }}"
+        tests:
+          - not_null
 
       - name: AMOUNT
         description: "{{ doc('amount') }}"
+        tests:
+          - not_null
 
       - name: FACT_STAKING_ACTIONS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/governance/gov__fact_staking_actions.yml
+++ b/models/gold/governance/gov__fact_staking_actions.yml
@@ -17,7 +17,7 @@ models:
         description: "{{ doc('tx_hash') }}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
@@ -28,7 +28,7 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id') }}"
@@ -59,9 +59,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/governance/gov__fact_staking_pool_balances.yml
+++ b/models/gold/governance/gov__fact_staking_pool_balances.yml
@@ -17,7 +17,7 @@ models:
         description: "{{ doc('tx_hash') }}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
@@ -28,7 +28,7 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id') }}"
@@ -49,9 +49,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/governance/gov__fact_staking_pool_balances.yml
+++ b/models/gold/governance/gov__fact_staking_pool_balances.yml
@@ -6,28 +6,52 @@ models:
       Staking pool balances as extracted from receipt logs when an individual makes a staking action.
       To calculate balance at a point in time, isolate a single record for each pool. This table is transactional-based, so balances are updated with every staking event by users.
       Note - the amount in balance is decimal adjusted by 10^24.
+    tests:
+      - dbt_utils.recency:
+          datepart: day
+          field: block_timestamp
+          interval: 1
 
     columns:
       - name: TX_HASH
         description: "{{ doc('tx_hash') }}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id') }}"
+        tests:
+          - not_null
 
       - name: ADDRESS
         description: "{{ doc('pool_address') }}"
+        tests:
+          - not_null
 
       - name: BALANCE
         description: "{{ doc('balance') }}"
+        tests:
+          - not_null
 
       - name: FACT_STAKING_POOL_BALANCES_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/governance/gov__fact_staking_pool_daily_balances.yml
+++ b/models/gold/governance/gov__fact_staking_pool_daily_balances.yml
@@ -30,9 +30,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/governance/gov__fact_staking_pool_daily_balances.yml
+++ b/models/gold/governance/gov__fact_staking_pool_daily_balances.yml
@@ -4,19 +4,35 @@ models:
   - name: gov__fact_staking_pool_daily_balances
     description: |-
       Aggregates the balances of each pool for each day, taking the last balance reported for each pool. This always excludes the present date.
+    tests:
+      - dbt_utils.recency:
+          datepart: day
+          field: date
+          interval: 2
 
     columns:
       - name: DATE
         description: "{{ doc('date') }}"
+        tests:
+          - not_null
 
       - name: ADDRESS
         description: "{{ doc('pool_address') }}"
+        tests:
+          - not_null
 
       - name: BALANCE
         description: "{{ doc('balance') }}"
+        tests:
+          - not_null
 
       - name: FACT_STAKING_POOL_DAILY_BALANCES_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/horizon/horizon__fact_decoded_actions.yml
+++ b/models/gold/horizon/horizon__fact_decoded_actions.yml
@@ -15,12 +15,18 @@ models:
 
       - name: TX_HASH
         description: "{{ doc('tx_hash')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: METHOD_NAME
         description: "{{ doc('method_name')}}"
@@ -45,6 +51,11 @@ models:
 
       - name: FACT_DECODED_ACTIONS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/horizon/horizon__fact_decoded_actions.yml
+++ b/models/gold/horizon/horizon__fact_decoded_actions.yml
@@ -17,7 +17,7 @@ models:
         description: "{{ doc('tx_hash')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
@@ -26,7 +26,7 @@ models:
         description: "{{ doc('block_timestamp')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: METHOD_NAME
         description: "{{ doc('method_name')}}"
@@ -53,9 +53,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/nft/nft__dim_nft_contract_metadata.yml
+++ b/models/gold/nft/nft__dim_nft_contract_metadata.yml
@@ -8,10 +8,14 @@ models:
     columns:
       - name: CONTRACT_ADDRESS
         description: "{{ doc('contract_address')}}"
-      
+        tests:
+          - not_null
+
       - name: NAME
         description: "{{ doc('name')}}"
-
+        tests:
+          - not_null
+          
       - name: SYMBOL
         description: "{{ doc('symbol')}}"
 
@@ -26,6 +30,11 @@ models:
 
       - name: DIM_NFT_CONTRACT_METADATA_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/nft/nft__dim_nft_contract_metadata.yml
+++ b/models/gold/nft/nft__dim_nft_contract_metadata.yml
@@ -32,9 +32,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/nft/nft__dim_nft_series_metadata.yml
+++ b/models/gold/nft/nft__dim_nft_series_metadata.yml
@@ -8,9 +8,14 @@ models:
     columns:
       - name: CONTRACT_ADDRESS
         description: "{{ doc('contract_address')}}"
+        tests:
+          - not_null
 
       - name: SERIES_ID
         description: "{{ doc('series_id')}}"
+        tests:
+          - not_null
+
       - name: SERIES_TITLE
         description: "{{ doc('series_title')}}"
 
@@ -25,6 +30,11 @@ models:
 
       - name: DIM_NFT_SERIES_METADATA_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/nft/nft__dim_nft_series_metadata.yml
+++ b/models/gold/nft/nft__dim_nft_series_metadata.yml
@@ -32,9 +32,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/nft/nft__fact_nft_mints.sql
+++ b/models/gold/nft/nft__fact_nft_mints.sql
@@ -25,7 +25,7 @@ WITH nft_mints AS (
         gas_burnt,
         transaction_fee,
         implied_price,
-        tx_status,
+        tx_status, -- TODO migrate to tx_succeeded
         mint_action_id,
         COALESCE(
             standard_nft_mint_id,

--- a/models/gold/nft/nft__fact_nft_mints.yml
+++ b/models/gold/nft/nft__fact_nft_mints.yml
@@ -8,15 +8,25 @@ models:
     columns:
       - name: RECEIPT_OBJECT_ID
         description: "{{ doc('receipt_object_id') }}"
+        tests:
+          - not_null
 
       - name: TX_HASH
         description: "{{ doc('tx_hash') }}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
+        tests:
+          - not_null
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: TOKEN_ID
         description: "{{ doc('nft_token_id') }}"
@@ -41,14 +51,15 @@ models:
                 - NUMBER
                 - FLOAT
 
-      - name: TX_SIGNER
-        description: "{{ doc('tx_signer') }}"
-
       - name: RECEIVER_ID
         description: "{{ doc('receiver_id')}}"
+        tests:
+          - not_null
 
       - name: SIGNER_ID
         description: "{{ doc('signer_id')}}"
+        tests:
+          - not_null
 
       - name: OWNER_ID
         description: "{{ doc('owner_id') }}"
@@ -80,11 +91,12 @@ models:
       - name: GAS_BURNT
         description: "{{ doc('gas_burnt') }}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER
                 - FLOAT
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: TRANSACTION_FEE
         description: "{{ doc('transaction_fee') }}"
@@ -93,6 +105,8 @@ models:
               column_type_list:
                 - NUMBER
                 - FLOAT
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: TX_STATUS
         description: "{{ doc('tx_status') }}"
@@ -101,9 +115,16 @@ models:
               column_type_list:
                 - STRING
                 - VARCHAR
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: FACT_NFT_MINTS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/nft/nft__fact_nft_mints.yml
+++ b/models/gold/nft/nft__fact_nft_mints.yml
@@ -15,7 +15,7 @@ models:
         description: "{{ doc('tx_hash') }}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
@@ -26,7 +26,7 @@ models:
         description: "{{ doc('block_timestamp')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: TOKEN_ID
         description: "{{ doc('nft_token_id') }}"
@@ -96,7 +96,7 @@ models:
                 - NUMBER
                 - FLOAT
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: TRANSACTION_FEE
         description: "{{ doc('transaction_fee') }}"
@@ -106,7 +106,7 @@ models:
                 - NUMBER
                 - FLOAT
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: TX_STATUS
         description: "{{ doc('tx_status') }}"
@@ -116,15 +116,15 @@ models:
                 - STRING
                 - VARCHAR
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: FACT_NFT_MINTS_ID
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/prices/price__fact_prices.sql
+++ b/models/gold/prices/price__fact_prices.sql
@@ -18,7 +18,7 @@ WITH oracle_prices AS (
         COALESCE(
             prices_oracle_id,
             {{ dbt_utils.generate_surrogate_key(
-                ['block_id', 'token_contract']
+                ['tx_hash', 'block_id', 'token_contract']
             ) }}
         ) AS fact_prices_id,
         COALESCE(inserted_timestamp, _inserted_timestamp, '2000-01-01' :: TIMESTAMP_NTZ) AS inserted_timestamp,

--- a/models/gold/prices/price__fact_prices.sql
+++ b/models/gold/prices/price__fact_prices.sql
@@ -21,8 +21,8 @@ WITH oracle_prices AS (
                 ['tx_hash', 'block_id', 'token_contract']
             ) }}
         ) AS fact_prices_id,
-        COALESCE(inserted_timestamp, _inserted_timestamp, '2000-01-01' :: TIMESTAMP_NTZ) AS inserted_timestamp,
-        COALESCE(modified_timestamp, _inserted_timestamp, '2000-01-01' :: TIMESTAMP_NTZ) AS modified_timestamp
+        inserted_timestamp,
+        modified_timestamp
     FROM
         {{ ref('silver__prices_oracle_s3') }}
 )

--- a/models/gold/prices/price__fact_prices.yml
+++ b/models/gold/prices/price__fact_prices.yml
@@ -4,14 +4,16 @@ models:
   - name: price__fact_prices
     description: |-
       This table presents asset prices for the NEAR blockchain from various sources. Presently, only the on-chain oracle is provide.
+    tests:
+      - dbt_utils.recency:
+          datepart: hours
+          field: timestamp
+          interval: 12
 
     columns:
       - name: TIMESTAMP
         description: "{{ doc('timestamp')}}"
         tests:
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ
@@ -72,6 +74,11 @@ models:
 
       - name: FACT_PRICES_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/prices/price__fact_prices.yml
+++ b/models/gold/prices/price__fact_prices.yml
@@ -76,9 +76,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/social/social__fact_addkey_events.yml
+++ b/models/gold/social/social__fact_addkey_events.yml
@@ -12,12 +12,18 @@ models:
 
       - name: TX_HASH
         description: "{{ doc('tx_hash')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: ALLOWANCE
         description: "{{ doc('allowance')}}"
@@ -27,6 +33,11 @@ models:
 
       - name: FACT_ADDKEY_EVENTS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/social/social__fact_addkey_events.yml
+++ b/models/gold/social/social__fact_addkey_events.yml
@@ -14,7 +14,7 @@ models:
         description: "{{ doc('tx_hash')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
@@ -23,7 +23,7 @@ models:
         description: "{{ doc('block_timestamp')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: ALLOWANCE
         description: "{{ doc('allowance')}}"
@@ -35,9 +35,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/social/social__fact_decoded_actions.yml
+++ b/models/gold/social/social__fact_decoded_actions.yml
@@ -12,12 +12,18 @@ models:
 
       - name: TX_HASH
         description: "{{ doc('tx_hash')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: SIGNER_ID
         description: "{{ doc('signer_id')}}"
@@ -30,6 +36,11 @@ models:
 
       - name: FACT_DECODED_ACTIONS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/social/social__fact_decoded_actions.yml
+++ b/models/gold/social/social__fact_decoded_actions.yml
@@ -14,7 +14,7 @@ models:
         description: "{{ doc('tx_hash')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
@@ -23,7 +23,7 @@ models:
         description: "{{ doc('block_timestamp')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: SIGNER_ID
         description: "{{ doc('signer_id')}}"
@@ -38,9 +38,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/social/social__fact_posts.yml
+++ b/models/gold/social/social__fact_posts.yml
@@ -14,7 +14,7 @@ models:
         description: "{{ doc('tx_hash')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
@@ -23,7 +23,7 @@ models:
         description: "{{ doc('block_timestamp')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: SIGNER_ID
         description: "{{ doc('signer_id')}}"
@@ -41,9 +41,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/social/social__fact_posts.yml
+++ b/models/gold/social/social__fact_posts.yml
@@ -12,12 +12,18 @@ models:
 
       - name: TX_HASH
         description: "{{ doc('tx_hash')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: SIGNER_ID
         description: "{{ doc('signer_id')}}"
@@ -33,6 +39,11 @@ models:
 
       - name: FACT_POSTS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/social/social__fact_profile_changes.yml
+++ b/models/gold/social/social__fact_profile_changes.yml
@@ -14,7 +14,7 @@ models:
         description: "{{ doc('tx_hash')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
@@ -23,7 +23,7 @@ models:
         description: "{{ doc('block_timestamp')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: SIGNER_ID
         description: "{{ doc('signer_id')}}"
@@ -38,9 +38,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/social/social__fact_profile_changes.yml
+++ b/models/gold/social/social__fact_profile_changes.yml
@@ -12,12 +12,18 @@ models:
 
       - name: TX_HASH
         description: "{{ doc('tx_hash')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: SIGNER_ID
         description: "{{ doc('signer_id')}}"
@@ -30,6 +36,11 @@ models:
 
       - name: FACT_PROFILE_CHANGES_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/social/social__fact_widget_deployments.yml
+++ b/models/gold/social/social__fact_widget_deployments.yml
@@ -12,12 +12,18 @@ models:
 
       - name: TX_HASH
         description: "{{ doc('tx_hash')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
 
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: SIGNER_ID
         description: "{{ doc('signer_id')}}"
@@ -42,6 +48,11 @@ models:
 
       - name: FACT_WIDGET_DEPLOYMENTS_ID
         description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/gold/social/social__fact_widget_deployments.yml
+++ b/models/gold/social/social__fact_widget_deployments.yml
@@ -14,7 +14,7 @@ models:
         description: "{{ doc('tx_hash')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
@@ -23,7 +23,7 @@ models:
         description: "{{ doc('block_timestamp')}}"
         tests:
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: SIGNER_ID
         description: "{{ doc('signer_id')}}"
@@ -50,9 +50,9 @@ models:
         description: "{{doc('id')}}"
         tests:
           - unique:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
           - not_null:
-              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '1 hour'
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
 
       - name: INSERTED_TIMESTAMP
         description: "{{doc('inserted_timestamp')}}"

--- a/models/silver/curated/silver__prices_oracle_s3.sql
+++ b/models/silver/curated/silver__prices_oracle_s3.sql
@@ -7,7 +7,6 @@
     tags = ['curated']
 ) }}
 
-{# TODO NOTE 12/11/2023 - d+i on block_id to update timestamp when it comes in. Can be improved. Block id is not properly unique. #}
 
 WITH token_labels AS (
 
@@ -103,7 +102,7 @@ FINAL AS (
 SELECT
     *,
     {{ dbt_utils.generate_surrogate_key(
-        ['block_id', 'token_contract']
+        ['tx_hash', 'block_id', 'token_contract']
     ) }} AS prices_oracle_id,
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp,

--- a/models/silver/streamline/silver__streamline_transactions_final.sql
+++ b/models/silver/streamline/silver__streamline_transactions_final.sql
@@ -40,8 +40,8 @@ WITH int_txs AS (
     {% else %}
     WHERE
       {{ partition_incremental_load(
-        2000,
-        1000,
+        6000,
+        3000,
         0
       ) }}
     {% endif %}
@@ -71,8 +71,8 @@ int_receipts AS (
     {% else %}
     WHERE
       {{ partition_incremental_load(
-        2000,
-        1000,
+        6000,
+        3000,
         0
       ) }}
     {% endif %}

--- a/models/silver/streamline/silver__streamline_transactions_final.sql
+++ b/models/silver/streamline/silver__streamline_transactions_final.sql
@@ -48,7 +48,7 @@ WITH int_txs AS (
       WHERE
         {{ partition_incremental_load(
           6000,
-          3000,
+          6000,
           0
         ) }}
       {% endif %}
@@ -88,7 +88,7 @@ int_receipts AS (
       WHERE
         {{ partition_incremental_load(
           6000,
-          3000,
+          6000,
           0
         ) }}
       {% endif %}

--- a/models/silver/streamline/silver__streamline_transactions_final.sql
+++ b/models/silver/streamline/silver__streamline_transactions_final.sql
@@ -30,23 +30,29 @@ WITH int_txs AS (
   FROM
     {{ ref('silver__streamline_transactions') }}
 
-    {% if var('IS_MIGRATION') %}
-    WHERE
-      {{ partition_incremental_load(
-        150000,
-        10000,
-        0
-      ) }}
+    {% if var('MANUAL_FIX') %}
+
+        WHERE
+            {{ partition_load_manual('front') }}
+            
     {% else %}
-    WHERE
-      {{ partition_incremental_load(
-        6000,
-        3000,
-        0
-      ) }}
-      OR _modified_timestamp >= (
-        SELECT MAX(_modified_timestamp) FROM {{ this }}
-      )
+
+      {% if var('IS_MIGRATION') %}
+      WHERE
+        {{ partition_incremental_load(
+          150000,
+          10000,
+          0
+        ) }}
+      {% else %}
+      WHERE
+        {{ partition_incremental_load(
+          6000,
+          3000,
+          0
+        ) }}
+      {% endif %}
+
     {% endif %}
 ),
 int_receipts AS (
@@ -64,23 +70,29 @@ int_receipts AS (
   FROM
     {{ ref('silver__streamline_receipts_final') }}
 
-    {% if var('IS_MIGRATION') %}
-    WHERE
-      {{ partition_incremental_load(
-        150000,
-        10000,
-        0
-      ) }}
+    {% if var('MANUAL_FIX') %}
+
+        WHERE
+            {{ partition_load_manual('front') }}
+            
     {% else %}
-    WHERE
-      {{ partition_incremental_load(
-        6000,
-        3000,
-        0
-      ) }}
-      OR _modified_timestamp >= (
-        SELECT MAX(_modified_timestamp) FROM {{ this }}
-      )
+
+      {% if var('IS_MIGRATION') %}
+      WHERE
+        {{ partition_incremental_load(
+          150000,
+          10000,
+          0
+        ) }}
+      {% else %}
+      WHERE
+        {{ partition_incremental_load(
+          6000,
+          3000,
+          0
+        ) }}
+      {% endif %}
+
     {% endif %}
 
 ),
@@ -97,9 +109,6 @@ int_blocks AS (
   WHERE
     _partition_by_block_number >= (
       SELECT MIN(_partition_by_block_number) FROM int_txs
-    )
-    OR _modified_timestamp >= (
-      SELECT MAX(_modified_timestamp) FROM {{ this }}
     )
 ),
 receipt_array AS (

--- a/models/silver/streamline/silver__streamline_transactions_final.sql
+++ b/models/silver/streamline/silver__streamline_transactions_final.sql
@@ -1,7 +1,6 @@
 {{ config(
   materialized = 'incremental',
-  incremental_strategy = 'merge',
-  merge_exclude_columns = ['inserted_timestamp'],
+  incremental_strategy = 'delete+insert',
   unique_key = 'tx_hash',
   cluster_by = ['_modified_timestamp::DATE', '_partition_by_block_number'],
   tags = ['receipt_map']
@@ -33,7 +32,7 @@ WITH int_txs AS (
     {% if var('MANUAL_FIX') %}
 
         WHERE
-            {{ partition_load_manual('front') }}
+            {{ partition_load_manual('no_buffer') }}
             
     {% else %}
 
@@ -73,7 +72,7 @@ int_receipts AS (
     {% if var('MANUAL_FIX') %}
 
         WHERE
-            {{ partition_load_manual('front') }}
+            {{ partition_load_manual('end') }}
             
     {% else %}
 

--- a/models/silver/streamline/silver__streamline_transactions_final.sql
+++ b/models/silver/streamline/silver__streamline_transactions_final.sql
@@ -44,6 +44,9 @@ WITH int_txs AS (
         3000,
         0
       ) }}
+      OR _modified_timestamp >= (
+        SELECT MAX(_modified_timestamp) FROM {{ this }}
+      )
     {% endif %}
 ),
 int_receipts AS (
@@ -75,6 +78,9 @@ int_receipts AS (
         3000,
         0
       ) }}
+      OR _modified_timestamp >= (
+        SELECT MAX(_modified_timestamp) FROM {{ this }}
+      )
     {% endif %}
 
 ),
@@ -91,6 +97,9 @@ int_blocks AS (
   WHERE
     _partition_by_block_number >= (
       SELECT MIN(_partition_by_block_number) FROM int_txs
+    )
+    OR _modified_timestamp >= (
+      SELECT MAX(_modified_timestamp) FROM {{ this }}
     )
 ),
 receipt_array AS (


### PR DESCRIPTION
Updates daily test to test gold views only.
Adds 1h buffer on fields that may be null.
Limits long running scans to 7 day lookback


Tweaks in models requiring FR:
 - atlas accts created
 - prices oracle

Pushes fix to txs final expanding partition window, and adding manual fix logic back.