### PR TITLE
fix blocktimestamp

### DIFF
--- a/models/silver/streamline/silver__streamline_receipts_final.sql
+++ b/models/silver/streamline/silver__streamline_receipts_final.sql
@@ -170,7 +170,7 @@ FINAL AS (
         _modified_timestamp
     FROM
         append_tx_hash r
-        LEFT JOIN blocks b USING (block_id)
+        INNER JOIN blocks b USING (block_id)
 )
 SELECT
     *,


### PR DESCRIPTION
We get receipts faster than blocks finish.