### PR TITLE
Transfer table

### DIFF
--- a/models/descriptions/transfer_type.md
+++ b/models/descriptions/transfer_type.md
@@ -1,0 +1,5 @@
+{% docs transfer_type %}
+
+Nature of the transfer
+
+{% enddocs %}

--- a/models/gold/core/core__fact_token_transfers.sql
+++ b/models/gold/core/core__fact_token_transfers.sql
@@ -1,0 +1,40 @@
+{{ config(
+    materialized = 'view',
+    secure = false,
+    tags = ['core']
+) }}
+
+WITH token_transfers AS (
+
+    SELECT
+        *
+    FROM
+        {{ ref('silver__token_transfers') }}
+)
+SELECT
+    block_id,
+    block_timestamp,
+    tx_hash,
+    action_id,
+    contract_address,
+    from_address,
+    to_address,
+    token_id,
+    raw_amount,
+    raw_amount_precise,
+    amount,
+    amount_usd,
+    transfer_type,
+    symbol,
+    token_price,
+    has_price,
+    COALESCE(
+        transfers_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['transfers_id']
+        ) }}
+    ) AS fact_token_transfers_id,
+    COALESCE(inserted_timestamp, _inserted_timestamp, '2000-01-01' :: TIMESTAMP_NTZ) AS inserted_timestamp,
+    COALESCE(modified_timestamp, _inserted_timestamp, '2000-01-01' :: TIMESTAMP_NTZ) AS modified_timestamp
+FROM
+    token_transfers

--- a/models/gold/core/core__fact_token_transfers.yml
+++ b/models/gold/core/core__fact_token_transfers.yml
@@ -1,0 +1,77 @@
+version: 2
+
+models:
+  - name: core__fact_token_transfers
+    description: This table records all the Transfer actions of the Near blockchain.
+    columns:
+      - name: BLOCK_ID
+        description: "{{ doc('block_id')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp')}}"
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
+
+      - name: TX_HASH
+        description: "{{ doc('tx_hash')}}"
+        tests:
+          - not_null
+
+      - name: CONTRACT_ADDRESS
+        description: "{{ doc('contract_address')}}"
+
+      - name: FROM_ADDRESS
+        description: "{{ doc('from_address')}}"
+
+      - name: TO_ADDRESS
+        description: "{{ doc('to_address')}}"
+
+      - name: TOKEN_ID
+        description: "{{ doc('token_id')}}"
+
+      - name: RAW_AMOUNT
+        description: "{{ doc('amount_raw')}}"
+
+      - name: RAW_AMOUNT_PRECISE
+        description: "{{ doc('amount_adj')}}"
+
+      - name: AMOUNT
+        description: "{{ doc('amount')}}"
+
+      - name: AMOUNT_USD
+        description: "{{ doc('amount_usd')}}"
+
+      - name: TRANSFER_TYPE
+        description: "{{ doc('transfer_type')}}"
+
+      - name: SYMBOL
+        description: "{{ doc('symbol')}}"
+
+      - name: TOKEN_PRICE
+        description: "{{ doc('price_usd')}}"
+
+      - name: HAS_PRICE
+        description: "Boolean value indicating if the token has a price"
+
+      - name: FACT_TOKEN_TRANSFERS_ID
+        description: "{{doc('id')}}"
+        tests:
+          - unique:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
+          - not_null:
+              where: inserted_timestamp BETWEEN SYSDATE() - INTERVAL '7 days' AND SYSDATE() - INTERVAL '2 hours'
+
+      - name: INSERTED_TIMESTAMP
+        description: "{{doc('inserted_timestamp')}}"
+
+      - name: MODIFIED_TIMESTAMP
+        description: "{{doc('modified_timestamp')}}"

--- a/models/silver/curated/silver__token_transfers.sql
+++ b/models/silver/curated/silver__token_transfers.sql
@@ -1,0 +1,414 @@
+{{ config(
+    materialized = 'incremental',
+    merge_exclude_columns = ["inserted_timestamp"],
+    cluster_by = ['block_timestamp::DATE'],
+    unique_key = 'transfers_id',
+    incremental_strategy = 'merge',
+    tags = ['curated']
+) }}
+
+WITH actions_events AS (
+
+    SELECT
+        *
+    FROM
+        {{ ref('silver__actions_events_function_call_s3') }}
+    WHERE
+        receipt_succeeded = TRUE
+        AND logs [0] IS NOT NULL
+
+{% if is_incremental() %}
+AND inserted_timestamp >= (
+    SELECT
+        MAX(inserted_timestamp)
+    FROM
+        {{ this }}
+)
+{% endif %}
+), swaps_raw AS (
+    SELECT
+        *
+    FROM
+        {{ ref('silver__dex_swaps_v2') }}
+
+{% if is_incremental() %}
+WHERE
+    inserted_timestamp >= (
+        SELECT
+            MAX(inserted_timestamp)
+        FROM
+            {{ this }}
+    )
+{% endif %}
+), token_prices AS (
+    SELECT
+        block_timestamp :: DATE AS DATE,
+        token_contract AS token_contract,
+        AVG(price_usd) AS price_usd,
+        MAX(symbol) AS symbol,
+        MAX(inserted_timestamp) AS inserted_timestamp
+    FROM
+        {{ ref('silver__prices_oracle_s3') }}
+    GROUP BY
+        1,
+        2,
+        inserted_timestamp
+
+{% if is_incremental() %}
+HAVING
+    inserted_timestamp >= (
+        SELECT
+            MAX(inserted_timestamp)
+        FROM
+            {{ this }}
+    )
+{% endif %}
+),
+metadata AS (
+    SELECT
+        *
+    FROM
+        {{ ref('silver__ft_contract_metadata') }}
+),
+----------------------------    Native Token Transfers   ------------------------------
+native_transfers AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        action_id,
+        signer_id AS from_address,
+        receiver_id AS to_address,
+        IFF(REGEXP_LIKE(deposit, '^[0-9]+$'), deposit, NULL) AS amount_unadjusted,
+        --numeric validation (there are some exceptions that needs to be ignored)
+        receipt_succeeded
+    FROM
+        actions_events
+    WHERE
+        (
+            action_name = 'Transfer'
+        )
+        OR (
+            action_name = 'FunctionCall'
+            AND method_name = 'near_deposit'
+        )
+        AND amount_unadjusted > 0
+),
+--------------------------------    NFT Transfers    --------------------------------
+nft_transfers AS (
+    SELECT
+        block_id,
+        signer_id,
+        block_timestamp,
+        tx_hash,
+        action_id,
+        TRY_PARSE_JSON(REPLACE(b.value, 'EVENT_JSON:')) AS DATA,
+        receiver_id AS contract_id
+    FROM
+        actions_events
+        JOIN LATERAL FLATTEN(
+            input => logs
+        ) b
+    WHERE
+        DATA :event IN (
+            'nft_transfer',
+            'nft_mint'
+        )
+),
+------------------------------   NEAR Tokens (NEP 141) --------------------------------
+swaps AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        receipt_object_id,
+        token_in AS contract_address,
+        signer_id AS from_address,
+        receiver_id AS to_address,
+        amount_in_raw :: variant AS amount_unadjusted,
+        'swap' AS memo
+    FROM
+        swaps_raw
+    UNION ALL
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        receipt_object_id,
+        token_in AS contract_address,
+        receiver_id AS from_address,
+        signer_id AS to_address,
+        amount_out_raw :: variant AS amount_unadjusted,
+        'swap' AS memo
+    FROM
+        swaps_raw
+),
+orders AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        action_id,
+        receiver_id,
+        TRY_PARSE_JSON(REPLACE(g.value, 'EVENT_JSON:')) AS DATA,
+        DATA :event AS event
+    FROM
+        actions_events
+        JOIN LATERAL FLATTEN(
+            input => logs
+        ) g
+    WHERE
+        DATA :event IN ('order_added')
+),
+orders_final AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        action_id,
+        f.value :sell_token :: STRING AS contract_address,
+        f.value :owner_id :: STRING AS from_address,
+        receiver_id :: STRING AS to_address,
+        (
+            f.value :original_amount
+        ) :: variant AS amount_unadjusted,
+        'order' AS memo
+    FROM
+        orders
+        JOIN LATERAL FLATTEN(
+            input => DATA :data
+        ) f
+    WHERE
+        amount_unadjusted > 0
+),
+add_liquidity AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        action_id,
+        REGEXP_SUBSTR(
+            SPLIT.value,
+            '"\\d+ ([^"]*)["]',
+            1,
+            1,
+            'e',
+            1
+        ) :: STRING AS contract_address,
+        NULL AS from_address,
+        receiver_id AS to_address,
+        REGEXP_SUBSTR(
+            SPLIT.value,
+            '"(\\d+) ',
+            1,
+            1,
+            'e',
+            1
+        ) :: variant AS amount_unadjusted,
+        'add_liquidity' AS memo
+    FROM
+        actions_events,
+        LATERAL FLATTEN (
+            input => SPLIT(
+                REGEXP_SUBSTR(
+                    logs [0],
+                    '\\["(.*?)"\\]'
+                ),
+                ','
+            )
+        ) SPLIT
+    WHERE
+        logs [0] LIKE 'Liquidity added [%minted % shares'
+),
+ft_transfers_mints AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        action_id,
+        TRY_PARSE_JSON(REPLACE(VALUE, 'EVENT_JSON:')) AS DATA,
+        receiver_id AS contract_address
+    FROM
+        actions_events
+        JOIN LATERAL FLATTEN(
+            input => logs
+        ) b
+    WHERE
+        DATA :event IN (
+            'ft_transfer',
+            'ft_mint'
+        )
+),
+ft_transfers_mints_final AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        action_id,
+        contract_address,
+        NVL(
+            f.value :old_owner_id,
+            NULL
+        ) :: STRING AS from_address,
+        NVL(
+            f.value :new_owner_id,
+            f.value :owner_id
+        ) :: STRING AS to_address,
+        f.value :amount :: variant AS amount_unadjusted,
+        f.value :memo :: STRING AS memo,
+    FROM
+        ft_transfers_mints
+        JOIN LATERAL FLATTEN(
+            input => DATA :data
+        ) f
+    WHERE
+        amount_unadjusted > 0
+),
+nep_transfers AS (
+    SELECT
+        *
+    FROM
+        ft_transfers_mints_final
+    UNION ALL
+    SELECT
+        *
+    FROM
+        orders_final
+    UNION ALL
+    SELECT
+        *
+    FROM
+        swaps
+    UNION ALL
+    SELECT
+        *
+    FROM
+        add_liquidity
+),
+------------------------------  MODELS --------------------------------
+nft_final AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        action_id,
+        contract_id :: STRING AS contract_address,
+        COALESCE(
+            A.value :old_owner_id,
+            signer_id
+        ) :: STRING AS from_address,
+        COALESCE(
+            A.value :new_owner_id,
+            A.value :owner_id
+        ) :: STRING AS to_address,
+        A.value :token_ids [0] :: STRING AS token_id,
+        NULL AS raw_amount,
+        NULL AS raw_amount_precise,
+        'nft' AS transfer_type
+    FROM
+        nft_transfers
+        JOIN LATERAL FLATTEN(
+            input => DATA :data
+        ) A
+    WHERE
+        token_id IS NOT NULL
+),
+native_final AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        action_id,
+        'wrap.near' :: STRING AS contract_address,
+        from_address :: STRING,
+        to_address :: STRING,
+        NULL AS token_id,
+        amount_unadjusted :: STRING AS raw_amount,
+        amount_unadjusted :: FLOAT AS raw_amount_precise,
+        'native' AS transfer_type
+    FROM
+        native_transfers
+),
+nep_final AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        action_id,
+        nep_transfers.contract_address :: STRING AS contract_address,
+        from_address,
+        to_address,
+        memo AS token_id,
+        amount_unadjusted :: STRING AS raw_amount,
+        amount_unadjusted :: FLOAT AS raw_amount_precise,
+        'nep141' AS transfer_type
+    FROM
+        nep_transfers
+),
+------------------------------   FINAL --------------------------------
+transfer_union AS (
+    SELECT
+        *
+    FROM
+        nep_final
+    UNION ALL
+    SELECT
+        *
+    FROM
+        native_final
+    UNION ALL
+    SELECT
+        *
+    FROM
+        nft_final
+),
+FINAL AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        action_id,
+        t.contract_address :: STRING AS contract_address,
+        from_address,
+        to_address,
+        token_id,
+        raw_amount,
+        raw_amount_precise,
+        CASE
+            WHEN transfer_type = 'native' THEN raw_amount_precise / 1e24
+            WHEN transfer_type = 'nep141' THEN raw_amount_precise / pow(
+                10,
+                b.decimals
+            )
+            WHEN transfer_type = 'nft' THEN NULL
+        END AS amount,
+        CASE
+            WHEN transfer_type = 'nft' THEN NULL
+            ELSE amount * price_usd
+        END AS amount_usd,
+        transfer_type,
+        b.symbol AS symbol,
+        price_usd AS token_price,
+        CASE
+            WHEN price_usd IS NULL THEN 'false'
+            ELSE 'true'
+        END AS has_price
+    FROM
+        transfer_union t
+        LEFT JOIN token_prices
+        ON block_timestamp :: DATE = DATE
+        AND token_prices.token_contract = t.contract_address
+        LEFT JOIN metadata b
+        ON token_prices.token_contract = b.contract_address
+)
+SELECT
+    *,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'action_id','contract_address','raw_amount','amount_usd','from_address','to_address','token_id']
+    ) }} AS transfers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    FINAL --- ToDo -- Check for duplicates -- Swaps has duplicates
+    --- token-id aka memo - identity

--- a/models/silver/curated/silver__token_transfers.yml
+++ b/models/silver/curated/silver__token_transfers.yml
@@ -1,0 +1,75 @@
+version: 2
+
+models:
+  - name: silver__token_transfers
+    description: |-
+      This table records all the Transfer actions of the Near blockchain.
+    columns:
+      - name: BLOCK_ID
+        description: "{{ doc('block_id')}}"
+
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null:
+              where: _inserted_timestamp <= current_timestamp - interval '10 hour'
+
+      - name: TX_HASH
+        description: "{{ doc('tx_hash')}}"
+
+      - name: ACTION_ID
+        description: "{{ doc('action_id')}}"
+
+      - name: CONTRACT_ADDRESS
+        description: "{{ doc('tx_signer')}}"
+
+      - name: FROM_ADDRESS
+        description: "{{ doc('from_address')}}"
+
+      - name: TO_ADDRESS
+        description: "{{ doc('to_address')}}"
+
+      - name: TOKEN_ID
+        description: "{{ doc('token_id')}}"
+
+      - name: RAW_AMOUNT
+        description: "{{ doc('amount_raw')}}"
+
+      - name: RAW_AMOUNT_PRECISE
+        description: "{{ doc('amount_adj')}}"
+
+      - name: AMOUNT
+        description: "{{ doc('amount')}}"
+
+      - name: AMOUNT_USD
+        description: "{{ doc('amount_usd')}}"
+
+      - name: TRANSFER_TYPE
+        description: "{{ doc('transfer_type')}}"
+
+      - name: SYMBOL
+        description: "{{ doc('symbol')}}"
+
+      - name: TOKEN_PRICE
+        description: "{{ doc('price_usd')}}"
+
+      - name: HAS_PRICE
+        description: "Boolean value indicating if the token has a price"
+
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp')}}"
+
+      - name: _MODIFIED_TIMESTAMP
+        description: "{{ doc('_modified_timestamp')}}"
+
+      - name: TRANSFERS_ID
+        description: "{{doc('id')}}"
+
+      - name: INSERTED_TIMESTAMP
+        description: "{{doc('inserted_timestamp')}}"
+
+      - name: MODIFIED_TIMESTAMP
+        description: "{{doc('modified_timestamp')}}"
+
+      - name: _INVOCATION_ID
+        description: "{{doc('invocation_id')}}"


### PR DESCRIPTION
Refactor and integration of
-- Nears Curation Challenge - 'https://flipsidecrypto.xyz/Hossein/transfer-sector-of-near-curation-challenge-zgM44F'
Following as much as possible  Ethereum Transfers table

Given this, I found that we have duplicates in our swaps table; these rows have different insert_timestamps but are the same records.

Added a transfer_type, so it's easier to filter and know the nature of the transfer. 