### PR TITLE
only first action

### DIFF
--- a/models/silver/curated/silver__token_transfers.sql
+++ b/models/silver/curated/silver__token_transfers.sql
@@ -31,6 +31,7 @@ WITH actions_events AS (
     WHERE
         receipt_succeeded = TRUE
         AND logs [0] IS NOT NULL
+        AND RIGHT(ACTION_ID, 1) = '0'
 
     {% if var("MANUAL_FIX") %}
       AND {{ partition_load_manual('no_buffer') }}


### PR DESCRIPTION
Gonna require a full refresh. Receipt get divided into action but each actions has logs receipt. Thats what we are using because of that we only need the first action of each reciept. 