### PR TITLE
Fix dupl

### DIFF
--- a/models/silver/curated/silver__token_transfers.sql
+++ b/models/silver/curated/silver__token_transfers.sql
@@ -142,7 +142,7 @@ swaps AS (
         signer_id AS to_address,
         amount_out_raw :: variant AS amount_unadjusted,
         'swap' AS memo,
-        swap_index + 1 as rn,
+        swap_index as rn,
         _inserted_timestamp,
         _modified_timestamp,
         _partition_by_block_number
@@ -351,7 +351,7 @@ swaps_final AS (
     s.to_address,
     s.amount_unadjusted,
     s.memo,
-    s.rn,
+    coalesce(t.rn, s.rn) as rn,
     s._inserted_timestamp,
     s._modified_timestamp,
     s._partition_by_block_number
@@ -433,7 +433,7 @@ nep_final AS (
     FROM
         nep_transfers
     qualify
-        row_number() over (partition by tx_hash, action_id, contract_address, from_address, to_address, amount_raw  order by _modified_timestamp desc) = 1
+        row_number() over (partition by tx_hash, action_id, contract_address, from_address, to_address, amount_raw  order by memo desc) = 1
 ),
 ------------------------------   FINAL --------------------------------
 transfer_union AS (

--- a/models/silver/curated/silver__token_transfers.sql
+++ b/models/silver/curated/silver__token_transfers.sql
@@ -349,25 +349,7 @@ nep_transfers AS (
     FROM
         add_liquidity
 ),
-nep_transfers_deduplicate AS (
-    SELECT
-        *,
-        ROW_NUMBER() OVER (
-            PARTITION BY
-                tx_hash,
-                contract_address,
-                from_address,
-                to_address,
-                amount_unadjusted,
-                memo
-            ORDER BY
-                memo desc
-        ) AS rna
-    FROM
-        nep_transfers
-)
 ------------------------------  MODELS --------------------------------
-
 native_final AS (
     SELECT
         block_id,

--- a/models/silver/curated/silver__token_transfers.sql
+++ b/models/silver/curated/silver__token_transfers.sql
@@ -123,7 +123,7 @@ swaps AS (
         token_in AS contract_address,
         signer_id AS from_address,
         receiver_id AS to_address,
-        amount_in_raw :: string AS amount_unadjusted,
+        amount_in_raw :: variant AS amount_unadjusted,
         'swap' AS memo,
         swap_index as rn,
         _inserted_timestamp,
@@ -140,7 +140,7 @@ swaps AS (
         token_out AS contract_address,
         receiver_id AS from_address,
         signer_id AS to_address,
-        amount_out_raw :: string AS amount_unadjusted,
+        amount_out_raw :: variant AS amount_unadjusted,
         'swap' AS memo,
         swap_index + 1 as rn,
         _inserted_timestamp,
@@ -345,7 +345,7 @@ swaps_final AS (
     s.block_id,
     s.block_timestamp,
     s.tx_hash,
-    action_id,
+    coalesce(t.action_id, s.receipt_object_id) as action_id,
     s.contract_address,
     s.from_address,
     s.to_address,
@@ -362,9 +362,8 @@ swaps_final AS (
     AND t.contract_address = s.contract_address
     AND t.from_address = s.from_address
     AND t.to_address = s.to_address
-    AND t.amount_unadjusted = s.amount_unadjusted;
-)
-
+    AND t.amount_unadjusted :: STRING = s.amount_unadjusted :: STRING
+),
 nep_transfers AS (
     SELECT
         *


### PR DESCRIPTION
FR require.

We are focusing on transactions that involve swaps and transfers, filtering them to avoid duplicates while ensuring we don't lose track of either transfers or swaps.






