### PR TITLE
bug fix: replaced left join with asof join for NFT sales usd prices

### DIFF
--- a/models/silver/curated/nft/sales/silver__nft_complete_nft_sales.sql
+++ b/models/silver/curated/nft/sales/silver__nft_complete_nft_sales.sql
@@ -192,11 +192,11 @@ FINAL AS (
         _partition_by_block_number
     FROM
         sales_union s
-        LEFT JOIN prices p
-        ON DATE_TRUNC(
-            'hour',
-            s.block_timestamp
-        ) = p.block_timestamp_hour
+        ASOF JOIN prices p
+        MATCH_CONDITION (
+            DATE_TRUNC('hour', s.block_timestamp) 
+            >= p.block_timestamp_hour
+        )
 )
 SELECT
     *,


### PR DESCRIPTION
Small change to resolve downstream missing `price_usd` data in`ez_nft_sales`. This join was recently used in `ez_token_transfers` [here](https://github.com/FlipsideCrypto/near-models/pull/364/files#diff-eea1478ab6c6914d1c39ef61b47c0ca4487ba547c31e24a246299299409c102cR98-R100) and will resolve to the latest `price_usd` available at runtime, rather than return null if not finding a match.

Related bug report: https://team-1612274056224.atlassian.net/browse/AN-5318 