### PR TITLE
remove fsc-utils

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -3,7 +3,5 @@ packages:
     version: 0.8.2
   - package: dbt-labs/dbt_utils
     version: 1.0.0
-  - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: "v1.29.0"
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]


### PR DESCRIPTION
- Removes `fsc_utils` package to prevent circular dependency when pulling in `near-models` to reuse gold layer transformations in `livequery gold UDTF's`

**Note**: This is just a temporary solution to circumvent the circular dependency and enable adhering to DRY principles while building out the `Near Gold UDTF's`