### PR TITLE
test fsc-utils w/ lq-base

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -4,6 +4,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: "STREAM-1111/add-lq-base"
+    revision: "main"
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -4,6 +4,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.32.0
+    revision: "STREAM-1111/add-lq-base"
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -4,6 +4,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: "main"
+    revision: v1.33.0
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]

--- a/selectors.yml
+++ b/selectors.yml
@@ -4,5 +4,5 @@ selectors:
     definition:
       union:
         - method: fqn
-          value: "livequery_models.deploy.core._utils"
+          value: "livequery_base.deploy.core._utils"
         


### PR DESCRIPTION
- Pins `fsc-utils` to `v1.33.0`
- Updates selector fqn `livequery_models.deploy.core._utils` -> `livequery_base.deploy.core._utils`