### PR TITLE
AN-5904/Defi Updates

### DIFF
--- a/models/gold/defi/defi__ez_intents.yml
+++ b/models/gold/defi/defi__ez_intents.yml
@@ -124,19 +124,19 @@ models:
         description: "{{ doc('blockchain') }}"
         tests:
           - not_null:
-              where: token_id not in ('nep141:a35923162c49cf95e6bf26623385eb431ad920d3.factory.bridge.near', 'nep141:purge-558.meme-cooking.near', 'nep141:noear-324.meme-cooking.near', 'nep141:abg-966.meme-cooking.near', 'nep141:gnear-229.meme-cooking.near', 'nep141:gnosis-0xddafbb505ad214d7b80b1f830fccc89b60fb7a83.omft.near', 'nep141:keypom.near') and token_id not like 'nep245%'
+              where: token_id not in ('nep141:eth.bridge.near', 'nep141:a35923162c49cf95e6bf26623385eb431ad920d3.factory.bridge.near', 'nep141:purge-558.meme-cooking.near', 'nep141:noear-324.meme-cooking.near', 'nep141:abg-966.meme-cooking.near', 'nep141:gnear-229.meme-cooking.near', 'nep141:gnosis-0xddafbb505ad214d7b80b1f830fccc89b60fb7a83.omft.near', 'nep141:keypom.near') and token_id not like 'nep245%'
 
       - name: CONTRACT_ADDRESS
         description: "{{ doc('contract_address') }}"
         tests:
           - not_null:
-              where: token_id not in ('nep141:a35923162c49cf95e6bf26623385eb431ad920d3.factory.bridge.near', 'nep141:purge-558.meme-cooking.near', 'nep141:noear-324.meme-cooking.near', 'nep141:abg-966.meme-cooking.near', 'nep141:gnear-229.meme-cooking.near', 'nep141:gnosis-0xddafbb505ad214d7b80b1f830fccc89b60fb7a83.omft.near', 'nep141:keypom.near') and token_id not like 'nep245%'
+              where: token_id not in ('nep141:eth.bridge.near', 'nep141:a35923162c49cf95e6bf26623385eb431ad920d3.factory.bridge.near', 'nep141:purge-558.meme-cooking.near', 'nep141:noear-324.meme-cooking.near', 'nep141:abg-966.meme-cooking.near', 'nep141:gnear-229.meme-cooking.near', 'nep141:gnosis-0xddafbb505ad214d7b80b1f830fccc89b60fb7a83.omft.near', 'nep141:keypom.near') and token_id not like 'nep245%'
 
       - name: IS_NATIVE
         description: "{{ doc('is_native') }}"
         tests:
           - not_null:
-              where: token_id not in ('nep141:a35923162c49cf95e6bf26623385eb431ad920d3.factory.bridge.near', 'nep141:purge-558.meme-cooking.near', 'nep141:noear-324.meme-cooking.near', 'nep141:abg-966.meme-cooking.near', 'nep141:gnear-229.meme-cooking.near', 'nep141:gnosis-0xddafbb505ad214d7b80b1f830fccc89b60fb7a83.omft.near', 'nep141:keypom.near') and token_id not like 'nep245%'
+              where: token_id not in ('nep141:eth.bridge.near', 'nep141:a35923162c49cf95e6bf26623385eb431ad920d3.factory.bridge.near', 'nep141:purge-558.meme-cooking.near', 'nep141:noear-324.meme-cooking.near', 'nep141:abg-966.meme-cooking.near', 'nep141:gnear-229.meme-cooking.near', 'nep141:gnosis-0xddafbb505ad214d7b80b1f830fccc89b60fb7a83.omft.near', 'nep141:keypom.near') and token_id not like 'nep245%'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - BOOLEAN
@@ -145,13 +145,13 @@ models:
         description: "{{ doc('symbol') }}"
         tests:
           - not_null:
-              where: token_id not in ('nep141:a35923162c49cf95e6bf26623385eb431ad920d3.factory.bridge.near', 'nep141:purge-558.meme-cooking.near', 'nep141:noear-324.meme-cooking.near', 'nep141:abg-966.meme-cooking.near', 'nep141:gnear-229.meme-cooking.near', 'nep141:gnosis-0xddafbb505ad214d7b80b1f830fccc89b60fb7a83.omft.near', 'nep141:keypom.near') and token_id not like 'nep245%'
+              where: token_id not in ('nep141:eth.bridge.near', 'nep141:a35923162c49cf95e6bf26623385eb431ad920d3.factory.bridge.near', 'nep141:purge-558.meme-cooking.near', 'nep141:noear-324.meme-cooking.near', 'nep141:abg-966.meme-cooking.near', 'nep141:gnear-229.meme-cooking.near', 'nep141:gnosis-0xddafbb505ad214d7b80b1f830fccc89b60fb7a83.omft.near', 'nep141:keypom.near') and token_id not like 'nep245%'
 
       - name: DECIMALS
         description: "{{ doc('decimals') }}"
         tests:
           - not_null:
-              where: token_id not in ('nep141:a35923162c49cf95e6bf26623385eb431ad920d3.factory.bridge.near', 'nep141:purge-558.meme-cooking.near', 'nep141:noear-324.meme-cooking.near', 'nep141:abg-966.meme-cooking.near', 'nep141:gnear-229.meme-cooking.near', 'nep141:gnosis-0xddafbb505ad214d7b80b1f830fccc89b60fb7a83.omft.near', 'nep141:keypom.near') and token_id not like 'nep245%'
+              where: token_id not in ('nep141:eth.bridge.near', 'nep141:a35923162c49cf95e6bf26623385eb431ad920d3.factory.bridge.near', 'nep141:purge-558.meme-cooking.near', 'nep141:noear-324.meme-cooking.near', 'nep141:abg-966.meme-cooking.near', 'nep141:gnear-229.meme-cooking.near', 'nep141:gnosis-0xddafbb505ad214d7b80b1f830fccc89b60fb7a83.omft.near', 'nep141:keypom.near') and token_id not like 'nep245%'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER
@@ -161,7 +161,7 @@ models:
         description: "{{ doc('amount_adj') }}"
         tests:
           - not_null:
-              where: token_id not in ('nep141:a35923162c49cf95e6bf26623385eb431ad920d3.factory.bridge.near', 'nep141:purge-558.meme-cooking.near', 'nep141:noear-324.meme-cooking.near', 'nep141:abg-966.meme-cooking.near', 'nep141:gnear-229.meme-cooking.near', 'nep141:gnosis-0xddafbb505ad214d7b80b1f830fccc89b60fb7a83.omft.near', 'nep141:keypom.near') and token_id not like 'nep245%'
+              where: token_id not in ('nep141:eth.bridge.near', 'nep141:a35923162c49cf95e6bf26623385eb431ad920d3.factory.bridge.near', 'nep141:purge-558.meme-cooking.near', 'nep141:noear-324.meme-cooking.near', 'nep141:abg-966.meme-cooking.near', 'nep141:gnear-229.meme-cooking.near', 'nep141:gnosis-0xddafbb505ad214d7b80b1f830fccc89b60fb7a83.omft.near', 'nep141:keypom.near') and token_id not like 'nep245%'
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER

--- a/models/silver/curated/defi/lending/burrow/silver__burrow_borrows.sql
+++ b/models/silver/curated/defi/lending/burrow/silver__burrow_borrows.sql
@@ -80,3 +80,5 @@ SELECT
     '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL
+WHERE
+    actions != 'fee_detail'

--- a/models/silver/curated/defi/lending/burrow/silver__burrow_collaterals.sql
+++ b/models/silver/curated/defi/lending/burrow/silver__burrow_collaterals.sql
@@ -90,3 +90,5 @@ SELECT
     '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL
+WHERE
+    actions != 'fee_detail'

--- a/models/silver/curated/defi/lending/burrow/silver__burrow_deposits.sql
+++ b/models/silver/curated/defi/lending/burrow/silver__burrow_deposits.sql
@@ -79,3 +79,5 @@ SELECT
     '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL
+WHERE
+    actions != 'fee_detail'

--- a/models/silver/curated/defi/lending/burrow/silver__burrow_repays.sql
+++ b/models/silver/curated/defi/lending/burrow/silver__burrow_repays.sql
@@ -86,3 +86,5 @@ SELECT
     '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL
+WHERE
+    actions != 'fee_detail'

--- a/models/silver/curated/defi/lending/burrow/silver__burrow_withdraws.sql
+++ b/models/silver/curated/defi/lending/burrow/silver__burrow_withdraws.sql
@@ -76,3 +76,5 @@ SELECT
     '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL
+WHERE
+    actions != 'fee_detail'


### PR DESCRIPTION
1. Adds another contract to ez intents exception list
2. Excludes the action `fee_update` from intermediate burrow models, which was causing false alerts on `not null` tests. Will drop those records from the model(s)