### PR TITLE
AN-6254/wrapped Near event transfers

### DIFF
--- a/models/gold/core/core__ez_token_transfers.sql
+++ b/models/gold/core/core__ez_token_transfers.sql
@@ -71,7 +71,8 @@ SELECT
     from_address,
     to_address,
     memo,
-    amount_unadj :: STRING AS amount_raw,
+    -- TODO do we need so many amount columns?
+    amount_unadj AS amount_raw,
     amount_unadj :: FLOAT AS amount_raw_precise,
     IFF(
         C.decimals IS NOT NULL,

--- a/models/silver/transfers/non_native/silver__token_transfer_ft_transfers_event.sql
+++ b/models/silver/transfers/non_native/silver__token_transfer_ft_transfers_event.sql
@@ -69,7 +69,7 @@ ft_transfers_final AS (
             input => log_data :data
         ) f
     WHERE
-        amount_unadj > 0
+        amount_unadj :: INT > 0
 )
 SELECT
     block_timestamp,

--- a/models/silver/transfers/non_native/silver__token_transfer_mints.sql
+++ b/models/silver/transfers/non_native/silver__token_transfer_mints.sql
@@ -68,7 +68,7 @@ ft_mints_final AS (
             input => log_data :data
         ) f
     WHERE
-        amount_unadj > 0
+        amount_unadj :: INT > 0
 )
 SELECT
     block_timestamp,

--- a/models/silver/transfers/non_native/silver__token_transfer_orders.sql
+++ b/models/silver/transfers/non_native/silver__token_transfer_orders.sql
@@ -63,7 +63,7 @@ orders_final AS (
             input => log_data :data
         ) f
     WHERE
-        amount_unadj > 0
+        amount_unadj :: INT > 0
 )
 SELECT
     block_timestamp,

--- a/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.sql
+++ b/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.sql
@@ -16,8 +16,8 @@ WITH actions AS (
         tx_hash,
         receipt_id,
         receipt_receiver_id AS contract_address,
-        IFF(method_name = 'near_deposit', receipt_receiver_id, receipt_predecessor_id) AS from_address,
-        IFF(method_name = 'near_deposit', receipt_predecessor_id, receipt_receiver_id) AS to_address,
+        IFF(action_data :method_name :: STRING = 'near_deposit', receipt_receiver_id, receipt_predecessor_id) AS from_address,
+        IFF(action_data :method_name :: STRING = 'near_deposit', receipt_predecessor_id, receipt_receiver_id) AS to_address,
         action_data :method_name :: STRING AS method_name,
         COALESCE(
             action_data :args :amount,

--- a/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.sql
+++ b/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.sql
@@ -16,8 +16,8 @@ WITH actions AS (
         tx_hash,
         receipt_id,
         receipt_receiver_id AS contract_address,
-        receipt_receiver_id AS from_address,
-        receipt_predecessor_id AS to_address,
+        IFF(method_name = 'near_deposit', receipt_receiver_id, receipt_predecessor_id) AS from_address,
+        IFF(method_name = 'near_deposit', receipt_predecessor_id, receipt_receiver_id) AS to_address,
         action_data :method_name :: STRING AS method_name,
         COALESCE(
             action_data :args :amount,

--- a/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.sql
+++ b/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.sql
@@ -22,7 +22,7 @@ WITH actions AS (
         COALESCE(
             action_data :args :amount,
             action_data :deposit
-         ) :: STRING AS amount_unadj,
+         ) :: variant AS amount_unadj,
         NULL AS memo,
         action_index AS rn,
         FLOOR(

--- a/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.sql
+++ b/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.sql
@@ -38,9 +38,7 @@ WITH actions AS (
         AND action_data :method_name :: STRING IN (
             'near_deposit',
             'near_withdraw'
-        ) 
-        -- temp lookback for dev
-        AND block_timestamp :: DATE > sysdate() - interval '90 days'
+        )
     {% if var("MANUAL_FIX") %}
         AND {{ partition_load_manual(
             'no_buffer',

--- a/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.sql
+++ b/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.sql
@@ -18,7 +18,11 @@ WITH actions AS (
         receipt_receiver_id AS contract_address,
         receipt_receiver_id AS from_address,
         receipt_predecessor_id AS to_address,
-        action_data :args :amount :: STRING AS amount_unadj,
+        action_data :method_name :: STRING AS method_name,
+        COALESCE(
+            action_data :args :amount,
+            action_data :deposit
+         ) :: STRING AS amount_unadj,
         NULL AS memo,
         action_index AS rn,
         FLOOR(
@@ -60,6 +64,7 @@ SELECT
     tx_hash,
     receipt_id,
     contract_address,
+    method_name,
     from_address,
     to_address,
     amount_unadj,

--- a/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.sql
+++ b/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.sql
@@ -22,7 +22,7 @@ WITH actions AS (
         COALESCE(
             action_data :args :amount,
             action_data :deposit
-         ) :: variant AS amount_unadj,
+        ) :: STRING AS amount_unadj,
         NULL AS memo,
         action_index AS rn,
         FLOOR(

--- a/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.yml
+++ b/models/silver/transfers/non_native/silver__token_transfer_wrapped_near.yml
@@ -1,0 +1,114 @@
+version: 2
+
+models:
+  - name: silver__token_transfer_wrapped_near
+    description: >
+      This model tracks wrapped NEAR token transfers, capturing both deposits and withdrawals
+      of NEAR tokens through the wrap.near contract. It includes transaction details, addresses,
+      and amounts for each transfer.
+
+    columns:
+      - name: block_id
+        description: The unique identifier of the block containing the transfer
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: NUMBER
+
+      - name: block_timestamp
+        description: The timestamp when the block was created
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: TIMESTAMP_NTZ
+
+      - name: tx_hash
+        description: The hash of the transaction containing the transfer
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+
+      - name: receipt_id
+        description: The unique identifier of the receipt containing the transfer
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+
+      - name: contract_address
+        description: The address of the wrap.near contract
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+
+      - name: method_name
+        description: The method name of the transfer (near_deposit or near_withdraw)
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+
+      - name: from_address
+        description: The address sending the wrapped NEAR tokens
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+
+      - name: to_address
+        description: The address receiving the wrapped NEAR tokens
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+
+      - name: amount_unadj
+        description: The unadjusted amount of wrapped NEAR tokens transferred
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+
+      - name: memo
+        description: Optional memo associated with the transfer
+
+      - name: rn
+        description: The action index within the transaction
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: NUMBER
+
+      - name: _partition_by_block_number
+        description: The block number used for partitioning
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: NUMBER
+
+      - name: transfers_wrapped_near_id
+        description: The unique identifier for each transfer
+        tests:
+          - not_null
+          - unique
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+
+      - name: inserted_timestamp
+        description: The timestamp when the record was inserted
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: TIMESTAMP_NTZ
+
+      - name: modified_timestamp
+        description: The timestamp when the record was last modified
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: TIMESTAMP_NTZ
+
+      - name: _invocation_id
+        description: The unique identifier for the dbt run that created this record

--- a/models/silver/transfers/non_native/silver__transfers_wrapped_near.sql
+++ b/models/silver/transfers/non_native/silver__transfers_wrapped_near.sql
@@ -1,0 +1,76 @@
+{{ config(
+    materialized = 'incremental',
+    merge_exclude_columns = ["inserted_timestamp"],
+    incremental_predicates = ["dynamic_range_predicate_custom","block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE', 'modified_timestamp::DATE'],
+    unique_key = 'transfers_wrapped_near_id',
+    incremental_strategy = 'merge',
+    tags = ['scheduled_non_core']
+) }}
+
+WITH actions AS (
+
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        receipt_id,
+        receipt_receiver_id AS contract_address,
+        receipt_receiver_id AS from_address,
+        receipt_predecessor_id AS to_address,
+        action_data :args :amount :: STRING AS amount_unadj,
+        NULL AS memo,
+        action_index AS rn,
+        FLOOR(
+            block_id,
+            -3
+        ) AS _partition_by_block_number
+    FROM
+        {{ ref('core__ez_actions') }}
+    WHERE
+        action_name = 'FunctionCall'
+        AND receipt_receiver_id = 'wrap.near'
+        AND receipt_succeeded
+        AND action_data :method_name :: STRING IN (
+            'near_deposit',
+            'near_withdraw'
+        ) 
+        -- temp lookback for dev
+        AND block_timestamp :: DATE > sysdate() - interval '90 days'
+    {% if var("MANUAL_FIX") %}
+        AND {{ partition_load_manual(
+            'no_buffer',
+            'floor(block_id, -3)'
+        ) }}
+    {% else %}
+
+        {% if is_incremental() %}
+        AND modified_timestamp >= (
+            SELECT
+                MAX(modified_timestamp)
+            FROM
+                {{ this }}
+        )
+        {% endif %}
+    {% endif %}
+)
+SELECT
+    block_id,
+    block_timestamp,
+    tx_hash,
+    receipt_id,
+    contract_address,
+    from_address,
+    to_address,
+    amount_unadj,
+    memo,
+    rn,
+    _partition_by_block_number,
+    {{ dbt_utils.generate_surrogate_key(
+        ['receipt_id', 'amount_unadj', 'from_address', 'to_address', 'rn']
+    ) }} AS transfers_wrapped_near_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    actions

--- a/models/silver/transfers/silver__token_transfers_complete.sql
+++ b/models/silver/transfers/silver__token_transfers_complete.sql
@@ -62,7 +62,7 @@ WITH native_transfers AS (
         predecessor_id AS from_address,
         receiver_id AS to_address,
         NULL AS memo,
-        amount_unadj,
+        amount_unadj :: STRING AS amount_unadj,
         'native' AS transfer_type,
         _partition_by_block_number,
         modified_timestamp
@@ -87,7 +87,7 @@ native_deposits AS (
         predecessor_id AS from_address,
         receiver_id AS to_address,
         NULL AS memo,
-        amount_unadj,
+        amount_unadj :: STRING AS amount_unadj,
         'native' AS transfer_type,
         _partition_by_block_number,
         modified_timestamp
@@ -112,7 +112,7 @@ ft_transfers_method AS (
         from_address,
         to_address,
         memo,
-        amount_unadj,
+        amount_unadj :: STRING AS amount_unadj,
         'nep141' AS transfer_type,
         _partition_by_block_number,
         modified_timestamp
@@ -136,7 +136,7 @@ ft_transfers_event AS (
         from_address,
         to_address,
         memo,
-        amount_unadj,
+        amount_unadj :: STRING AS amount_unadj,
         'nep141' AS transfer_type,
         _partition_by_block_number,
         modified_timestamp
@@ -160,7 +160,7 @@ mints AS (
         from_address,
         to_address,
         memo,
-        amount_unadj,
+        amount_unadj :: STRING AS amount_unadj,
         'nep141' AS transfer_type,
         _partition_by_block_number,
         modified_timestamp
@@ -184,7 +184,7 @@ orders AS (
         from_address,
         to_address,
         memo,
-        amount_unadj,
+        amount_unadj :: STRING AS amount_unadj,
         'nep141' AS transfer_type,
         _partition_by_block_number,
         modified_timestamp
@@ -208,7 +208,7 @@ liquidity AS (
         from_address,
         to_address,
         memo,
-        amount_unadj,
+        amount_unadj :: STRING AS amount_unadj,
         'nep141' AS transfer_type,
         _partition_by_block_number,
         modified_timestamp
@@ -232,7 +232,7 @@ wrapped_near AS (
         from_address,
         to_address,
         memo,
-        amount_unadj,
+        amount_unadj :: STRING AS amount_unadj,
         'nep141' AS transfer_type,
         _partition_by_block_number,
         modified_timestamp


### PR DESCRIPTION
Adds wrapping/unwrapping of wNEAR to transfers model as a FT transfer.

Example TX:
```sql
select * from near.core.ez_token_transfers
where tx_hash = 'FbfEkWaoeAnZZXQfj2pdPh5aNC5PxMeJRXjiR7JtMTNF'
and block_timestamp :: date = '2025-05-14'
order by block_id
```
User swaps from Zcash to NEAR via Ref. We properly map the flow of tokens except that in one step (receipt `7FtkAsEdxv97jt3y8scpJBDY6b4EMvVz2YjBsaAZKWM1`) the protocol unwraps wNEAR before transferring native NEAR to the user. So, the flow of tokens shows `wrap.near` sending 556.69852912 NEAR to Ref and then Ref sending that to the swapper, but we are missing the piece where ref burns 556.69852912 wNEAR (a transfer of wNEAR from Ref to `wrap.near`).

I genuinely don't know why `amount_unadj` is cast to variant in the intermediate models. Was getting type error in complete, so casting to str in there.